### PR TITLE
Fix for PACKED array on PHP 8.2

### DIFF
--- a/kernel/excel.c
+++ b/kernel/excel.c
@@ -627,7 +627,8 @@ PHP_METHOD(vtiful_xls, header)
  */
 PHP_METHOD(vtiful_xls, data)
 {
-    zend_ulong column_index = 0;
+    zend_ulong column_index = 0, index;
+    zend_string *key;
     zval *data = NULL, *data_r_value = NULL;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -651,17 +652,16 @@ PHP_METHOD(vtiful_xls, data)
 
         column_index = 0;
 
-        ZEND_HASH_FOREACH_BUCKET(Z_ARRVAL_P(data_r_value), Bucket *bucket)
+        ZEND_HASH_FOREACH_KEY_VAL_IND(Z_ARRVAL_P(data_r_value), index, key, data) {
             // numeric index rewriting
-            if (bucket->key == NULL) {
-                column_index = bucket->h;
+            if (key == NULL) {
+                column_index = index;
             }
-
-            type_writer(&bucket->val, SHEET_CURRENT_LINE(obj), column_index, &obj->write_ptr, NULL, obj->format_ptr.format);
+            type_writer(data, SHEET_CURRENT_LINE(obj), column_index, &obj->write_ptr, NULL, obj->format_ptr.format);
 
             // next number index
             ++column_index;
-        ZEND_HASH_FOREACH_END();
+        } ZEND_HASH_FOREACH_END();
 
         SHEET_LINE_ADD(obj)
     ZEND_HASH_FOREACH_END();


### PR DESCRIPTION
Without this lot of tests fail, example
```
========DIFF========
001+ array(2) {
001- array(4) {
       [0]=>
       string(6) "Item_3"
       [1]=>
005-   string(6) "Cost_3"
006-   [2]=>
       int(10)
008-   [3]=>
009-   float(10.9999995)
     }
========DONE========
FAIL Check for vtiful presence [tests/open_xlsx_next_row_skip_rows.phpt] 

```

With this change:
```
=====================================================================
PHP         : /opt/remi/php82/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/xlswriter/tmp-php.ini
More .INIs  :  
---------------------------------------------------------------------
PHP         : /opt/remi/php82/root/usr/bin/php-cgi 
PHP_SAPI    : cgi-fcgi
PHP_VERSION : 8.2.0RC2
ZEND_VERSION: 4.2.0RC2
PHP_OS      : Linux - Linux builder.remirepo.net 5.19.8-100.fc35.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Sep 8 19:23:03 UTC 2022 x86_64
INI actual  : /work/GIT/pecl-and-ext/xlswriter/tmp-php.ini
More .INIs  : 
--------------------------------------------------------------------- 
CWD         : /work/GIT/pecl-and-ext/xlswriter
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2022-09-16 09:42:25
=====================================================================
PASS Check for vtiful presence [tests/001.phpt] 
PASS Check for vtiful presence [tests/002.phpt] 
PASS Check for vtiful presence [tests/003.phpt] 
PASS Check for vtiful presence [tests/004.phpt] 
PASS Check for vtiful presence [tests/005.phpt] 
PASS Check for vtiful presence [tests/006.phpt] 
PASS Check for vtiful presence [tests/007.phpt] 
PASS Check for vtiful presence [tests/008.phpt] 
PASS Check for vtiful presence [tests/009.phpt] 
PASS Check for vtiful presence [tests/010.phpt] 
PASS Check for vtiful presence [tests/011.phpt] 
PASS Check for vtiful presence [tests/012.phpt] 
PASS Check for vtiful presence [tests/013.phpt] 
PASS Check for vtiful presence [tests/014.phpt] 
PASS Check for vtiful presence [tests/015.phpt] 
PASS Check for vtiful presence [tests/016.phpt] 
PASS Check for vtiful presence [tests/018.phpt] 
PASS Check for vtiful presence [tests/activate_sheet.phpt] 
PASS Check for vtiful presence [tests/chart_axis_name_x.phpt] 
PASS Check for vtiful presence [tests/chart_axis_name_y.phpt] 
PASS Check for vtiful presence [tests/chart_line.phpt] 
PASS Check for vtiful presence [tests/chart_resource.phpt] 
PASS Check for vtiful presence [tests/chart_series.phpt] 
PASS Check for vtiful presence [tests/chart_series_name.phpt] 
PASS Check for vtiful presence [tests/chart_style.phpt] 
PASS Check for vtiful presence [tests/chart_title.phpt] 
PASS Check for vtiful presence [tests/close.phpt] 
PASS Check for vtiful presence [tests/column_index_from_string.phpt] 
PASS Check for vtiful presence [tests/const_memory.phpt] 
PASS Check for vtiful presence [tests/const_memory_index_out_range.phpt] 
PASS Check for vtiful presence [tests/data_reference.phpt] 
PASS Check for vtiful presence [tests/data_string_key.phpt] 
PASS Check for vtiful presence [tests/default_format.phpt] 
PASS Check for vtiful presence [tests/exist_sheet.phpt] 
PASS Check for vtiful presence [tests/first.phpt] 
PASS Check for vtiful presence [tests/fix-207.phpt] 
PASS Check for vtiful presence [tests/fix-243.phpt] 
PASS Check for vtiful presence [tests/format_align.phpt] 
PASS Check for vtiful presence [tests/format_background.phpt] 
PASS Check for vtiful presence [tests/format_border.phpt] 
PASS Check for vtiful presence [tests/format_border_color.phpt] 
PASS Check for vtiful presence [tests/format_border_color_of_the_four_sides_1.phpt] 
PASS Check for vtiful presence [tests/format_border_color_of_the_four_sides_2.phpt] 
PASS Check for vtiful presence [tests/format_font.phpt] 
PASS Check for vtiful presence [tests/format_font_color.phpt] 
PASS Check for vtiful presence [tests/format_font_size.phpt] 
PASS Check for vtiful presence [tests/format_font_strikeout.phpt] 
PASS Check for vtiful presence [tests/format_number.phpt] 
PASS Check for vtiful presence [tests/format_unlocked.phpt] 
PASS Check for vtiful presence [tests/format_wrap.phpt] 
PASS Check for vtiful presence [tests/freeze_panes.phpt] 
PASS Check for vtiful presence [tests/get_set_current_line.phpt] 
PASS Check for vtiful presence [tests/gridlines.phpt] 
PASS Check for vtiful presence [tests/header_format.phpt] 
PASS Check for vtiful presence [tests/hide.phpt] 
PASS Check for vtiful presence [tests/image_no_styles.phpt] 
PASS Check for vtiful presence [tests/image_width_height_styles.phpt] 
PASS Check for vtiful presence [tests/insert_comment.phpt] 
PASS Check for vtiful presence [tests/insert_date_custom_format.phpt] 
PASS Check for vtiful presence [tests/insert_date_default_format.phpt] 
PASS Check for vtiful presence [tests/insert_date_resource_format.phpt] 
PASS Check for vtiful presence [tests/insert_text_resource_format.phpt] 
PASS Check for vtiful presence [tests/insert_url_format.phpt] 
PASS Check for vtiful presence [tests/insert_url_no_format.phpt] 
PASS Check for vtiful presence [tests/margins.phpt] 
PASS Check for vtiful presence [tests/merge_cell_type_writer.phpt] 
PASS Check for vtiful presence [tests/multiple_file.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_file.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_file_not_found.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_get_data.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_get_data_bignumbers.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_get_data_skip_empty.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_get_data_skip_hidden_rows.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_get_data_skip_rows.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_get_data_with_set_type.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_get_sheet_not_found_data.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_global_data_type.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_cell_callback.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_cell_callback_with_data_type.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_row.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_row_skip_empty.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_row_skip_rows.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_row_with_data_type_date.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_row_with_data_type_date_array_index.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_row_with_data_type_string.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_next_row_with_set_type.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_sheet.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_sheet_flag.phpt] 
PASS Check for vtiful presence [tests/open_xlsx_sheet_list.phpt] 
PASS Check for vtiful presence [tests/paper.phpt] 
PASS Check for vtiful presence [tests/printed.phpt] 
PASS Check for vtiful presence [tests/protection.phpt] 
PASS Check for vtiful presence [tests/protection_password.phpt] 
PASS Check for vtiful presence [tests/rich_string.phpt] 
PASS Check for vtiful presence [tests/sheet_add.phpt] 
PASS Check for vtiful presence [tests/sheet_checkout.phpt] 
PASS Check for vtiful presence [tests/show_comment.phpt] 
PASS Check for vtiful presence [tests/string_from_column_index.phpt] 
PASS Check for vtiful presence [tests/timestamp_from_date_double.phpt] 
PASS Check for vtiful presence [tests/validation_limiting_input_to_a_value_in_a_dropdown_list.phpt] 
PASS Check for vtiful presence [tests/validation_limiting_input_to_an_integer_greater_than_a_fixed_value.phpt] 
PASS Check for vtiful presence [tests/validation_limiting_input_to_an_integer_in_a_fixed_range.phpt] 
PASS Check for vtiful presence [tests/validation_limiting_input_to_an_integer_outside_a_fixed_range.phpt] 
PASS Check for vtiful presence [tests/validation_limiting_to_a_single_or_range_cell.phpt] 
PASS Check for vtiful presence [tests/version.phpt] 
PASS Check for vtiful presence [tests/writer_exception.phpt] 
PASS Check for vtiful presence [tests/xlsx_to_csv.phpt] 
PASS Check for vtiful presence [tests/xlsx_to_csv_callback.phpt] 
PASS Check for vtiful presence [tests/xlsx_to_csv_callback_custom_delimiter.phpt] 
PASS Check for vtiful presence [tests/xlsx_to_csv_custom_delimiter.phpt] 
PASS Check for vtiful presence [tests/xlsx_to_csv_skip_rows.phpt] 
PASS Check for vtiful presence [tests/xlsx_to_csv_skip_rows_callback.phpt] 
PASS Check for vtiful presence [tests/zoom.phpt] 
=====================================================================
TIME END 2022-09-16 09:42:26

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   17
---------------------------------------------------------------------

Number of tests :  113               113
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :  113 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================

```