### PR TITLE
Autotools: Refactor configure options

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,17 +1,35 @@
-PHP_ARG_WITH(xlswriter, xlswriter support,
-[  --with-xlswriter         Include xlswriter support], yes)
+PHP_ARG_WITH([xlswriter],
+    [xlswriter support],
+    [AS_HELP_STRING([--without-xlswriter],
+        [Disable xlswriter support])],
+    [yes])
 
-PHP_ARG_WITH(libxlsxwriter, system libxlsxwriter,
-[  --with-libxlsxwriter=DIR Use system libxlsxwriter], no, no)
+PHP_ARG_WITH([libxlsxwriter],
+    [system libxlsxwriter],
+    [AS_HELP_STRING([[--with-libxlsxwriter[=DIR]]],
+        [Use system libxlsxwriter])],
+    [no],
+    [no])
 
-PHP_ARG_WITH(libxlsxio, system libxlsxio,
-[  --with-libxlsxio=DIR     Use system libxlsxio], no, no)
+PHP_ARG_WITH([libxlsxio],
+    [system libxlsxio],
+    [AS_HELP_STRING([[--with-libxlsxio[=DIR]]],
+        [Use system libxlsxio])],
+    [no],
+    [no])
 
-PHP_ARG_WITH(openssl, openssl MD5,
-[  --with-openssl=DIR   Use openssl MD5], no, no)
+PHP_ARG_WITH([openssl],
+    [openssl MD5],
+    [AS_HELP_STRING([[--with-openssl[=DIR]]],
+        [Use openssl MD5])],
+    [no],
+    [no])
 
-PHP_ARG_ENABLE(reader, enable xlsx reader support,
-[  --enable-reader          Enable xlsx reader?], yes, yes)
+PHP_ARG_ENABLE([reader],
+    [whether to enable the xlsx reader support],
+    [AS_HELP_STRING([--disable-reader],
+        [Disable xlsx reader])],
+    [yes])
 
 if test "$PHP_XLSWRITER" != "no"; then
     xls_writer_sources="

--- a/package.xml
+++ b/package.xml
@@ -33,11 +33,11 @@
   <email>wjx@php.net</email>
   <active>yes</active>
  </lead>
- <date>2024-08-28</date>
+ <date>2024-09-04</date>
  <time>00:00:00</time>
  <version>
-  <release>1.5.6</release>
-  <api>1.5.6</api>
+  <release>1.5.7</release>
+  <api>1.5.7</api>
  </version>
  <stability>
   <release>stable</release>
@@ -45,7 +45,7 @@
  </stability>
  <license uri="https://github.com/viest/php-ext-excel-export/blob/master/LICENSE">BSD license</license>
  <notes>
-- Fix: format resource memory leak.
+- Fix: insertDate memory leak.
  </notes>
  <contents>
   <dir name="/">
@@ -318,6 +318,22 @@
   <configureoption default="yes" name="enable-reader" prompt="enable reader supports?" />
  </extsrcrelease>
  <changelog>
+  <release>
+   <date>2024-08-28</date>
+   <time>00:00:00</time>
+   <version>
+    <release>1.5.6</release>
+    <api>1.5.6</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/viest/php-ext-excel-export/blob/master/LICENSE">BSD license</license>
+   <notes>
+    - Fix: format resource memory leak.
+   </notes>
+  </release>
   <release>
    <date>2023-05-15</date>
    <time>00:00:00</time>

--- a/php_xlswriter.h
+++ b/php_xlswriter.h
@@ -18,7 +18,7 @@
 extern zend_module_entry xlswriter_module_entry;
 #define phpext_xlswriter_ptr &xlswriter_module_entry
 
-#define PHP_XLSWRITER_VERSION "1.5.6"
+#define PHP_XLSWRITER_VERSION "1.5.7"
 #define PHP_XLSWRITER_AUTHOR  "Jiexing.Wang (wjx@php.net)"
 
 extern int le_xls_writer;


### PR DESCRIPTION
- The AS_HELP_STRING prettifies the `./configure -h` output
- Argument quoted
- Configure options that are by default enabled have the opposite option in the help output
- --enable-reader option 5th argument has been removed because that is meant only to the main argument to set additional ext_shared variables and some other internal handling
- Check messages adjusted a bit