### PR TITLE
fgetcsv default values are deprecated with 8.4

### DIFF
--- a/tests/xlsx_to_csv_callback.phpt
+++ b/tests/xlsx_to_csv_callback.phpt
@@ -30,8 +30,8 @@ var_dump($csvResult);
 
 $fp = fopen('./tests/file.csv', 'r');
 
-var_dump(fgetcsv($fp));
-var_dump(fgetcsv($fp));
+var_dump(fgetcsv($fp, 1000, ',', '"', '\\'));
+var_dump(fgetcsv($fp, 1000, ',', '"', '\\'));
 ?>
 --CLEAN--
 <?php

--- a/tests/xlsx_to_csv_callback_custom_delimiter.phpt
+++ b/tests/xlsx_to_csv_callback_custom_delimiter.phpt
@@ -30,7 +30,7 @@ if (($csvHandler = fopen('./tests/file.csv', 'r')) === FALSE) {
     die('csv file open failure');
 }
 
-while (($data = fgetcsv($csvHandler, 1000, ';')) !== FALSE) {
+while (($data = fgetcsv($csvHandler, 1000, ';', '"', '\\')) !== FALSE) {
     var_dump($data);
 }
 ?>

--- a/tests/xlsx_to_csv_custom_delimiter.phpt
+++ b/tests/xlsx_to_csv_custom_delimiter.phpt
@@ -28,7 +28,7 @@ if (($csvHandler = fopen('./tests/file.csv', 'r')) === FALSE) {
     die('csv file open failure');
 }
 
-while (($data = fgetcsv($csvHandler, 1000, ';')) !== FALSE) {
+while (($data = fgetcsv($csvHandler, 1000, ';', '"', '\\')) !== FALSE) {
     var_dump($data);
 }
 ?>


### PR DESCRIPTION
Using 8.4.0RC1

                                                    
```
========DIFF========
     bool(true)
002+ 
003+ Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /dev/shm/BUILD/php84-php-pecl-xlswriter-1.5.7/xlswriter-1.5.7/tests/xlsx_to_csv_callback.php on line 25
     array(2) {
       [0]=>
       string(4) "Item"
       [1]=>
       string(4) "Cost"
     }
010+ 
011+ Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /dev/shm/BUILD/php84-php-pecl-xlswriter-1.5.7/xlswriter-1.5.7/tests/xlsx_to_csv_callback.php on line 26
     array(4) {
       [0]=>
       string(6) "Item_1"
--
========DONE========
FAIL Check for vtiful presence [tests/xlsx_to_csv_callback.phpt] 
                                                    
========DIFF========
     bool(true)
002+ 
003+ Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /dev/shm/BUILD/php84-php-pecl-xlswriter-1.5.7/xlswriter-1.5.7/tests/xlsx_to_csv_callback_custom_delimiter.php on line 25
     array(2) {
       [0]=>
       string(4) "Item"
       [1]=>
       string(4) "Cost"
     }
010+ 
011+ Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /dev/shm/BUILD/php84-php-pecl-xlswriter-1.5.7/xlswriter-1.5.7/tests/xlsx_to_csv_callback_custom_delimiter.php on line 25
     array(4) {
       [0]=>
       string(6) "Item_1"
--
       [3]=>
       string(10) "10.9999995"
     }
022+ 
023+ Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /dev/shm/BUILD/php84-php-pecl-xlswriter-1.5.7/xlswriter-1.5.7/tests/xlsx_to_csv_callback_custom_delimiter.php on line 25
========DONE========
FAIL Check for vtiful presence [tests/xlsx_to_csv_callback_custom_delimiter.phpt] 
                                                   
========DIFF========
     bool(true)
002+ 
003+ Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /dev/shm/BUILD/php84-php-pecl-xlswriter-1.5.7/xlswriter-1.5.7/tests/xlsx_to_csv_custom_delimiter.php on line 23
     array(2) {
       [0]=>
       string(4) "Item"
       [1]=>
       string(4) "Cost"
     }
010+ 
011+ Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /dev/shm/BUILD/php84-php-pecl-xlswriter-1.5.7/xlswriter-1.5.7/tests/xlsx_to_csv_custom_delimiter.php on line 23
     array(4) {
       [0]=>
       string(6) "Item_1"
--
       [3]=>
       string(10) "10.9999995"
     }
022+ 
023+ Deprecated: fgetcsv(): the $escape parameter must be provided as its default value will change in /dev/shm/BUILD/php84-php-pecl-xlswriter-1.5.7/xlswriter-1.5.7/tests/xlsx_to_csv_custom_delimiter.php on line 23
========DONE========
FAIL Check for vtiful presence [tests/xlsx_to_csv_custom_delimiter.phpt] 

```