### PR TITLE
Set outline settings

### DIFF
--- a/include/xlswriter.h
+++ b/include/xlswriter.h
@@ -355,6 +355,7 @@ void printed_direction(xls_resource_write_t *res, unsigned int direction);
 void xls_file_path(zend_string *file_name, zval *dir_path, zval *file_path);
 void freeze_panes(xls_resource_write_t *res, zend_long row, zend_long column);
 void margins(xls_resource_write_t *res, double left, double right, double top, double bottom);
+void outline_settings(xls_resource_write_t *res, uint8_t visible, uint8_t symbols_below, uint8_t symbols_right, uint8_t auto_style);
 void set_row(zend_string *range, double height, xls_resource_write_t *res, lxw_format *format, lxw_row_col_options *user_options);
 void validation(xls_resource_write_t *res, zend_string *range, lxw_data_validation *validation);
 void set_column(zend_string *range, double width, xls_resource_write_t *res, lxw_format *format, lxw_row_col_options *user_options);

--- a/kernel/excel.c
+++ b/kernel/excel.c
@@ -1230,10 +1230,10 @@ PHP_METHOD(vtiful_xls, defaultRowOptions)
  */
 PHP_METHOD(vtiful_xls, outlineSettings)
 {
-    bool visible = true;
-    bool below = true;
-    bool right = true;
-    bool auto_style = false;
+    zend_bool visible = 1;
+    zend_bool below = 1;
+    zend_bool right = 1;
+    zend_bool auto_style = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 4)
             Z_PARAM_OPTIONAL

--- a/kernel/excel.c
+++ b/kernel/excel.c
@@ -234,6 +234,13 @@ ZEND_BEGIN_ARG_INFO_EX(xls_set_default_row_options_arginfo, 0, 0, 0)
                 ZEND_ARG_INFO(0, hidden)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(xls_set_outline_settings_arginfo, 0, 0, 0)
+                ZEND_ARG_INFO(0, visible)
+                ZEND_ARG_INFO(0, below)
+                ZEND_ARG_INFO(0, right)
+                ZEND_ARG_INFO(0, auto_style)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(xls_open_file_arginfo, 0, 0, 1)
                 ZEND_ARG_INFO(0, zs_file_name)
 ZEND_END_ARG_INFO()
@@ -1219,6 +1226,31 @@ PHP_METHOD(vtiful_xls, defaultRowOptions)
 }
 /* }}} */
 
+/** {{{ \Vtiful\Kernel\Excel::outlineSettings(bool $visible = true, bool $below = true, bool $right = true, bool $autoStyle = false)
+ */
+PHP_METHOD(vtiful_xls, outlineSettings)
+{
+    bool visible = true;
+    bool below = true;
+    bool right = true;
+    bool auto_style = false;
+
+    ZEND_PARSE_PARAMETERS_START(0, 4)
+            Z_PARAM_OPTIONAL
+            Z_PARAM_BOOL_OR_NULL(visible, _dummy)
+            Z_PARAM_BOOL_OR_NULL(below, _dummy)
+            Z_PARAM_BOOL_OR_NULL(right, _dummy)
+            Z_PARAM_BOOL_OR_NULL(auto_style, _dummy)
+    ZEND_PARSE_PARAMETERS_END();
+
+    ZVAL_COPY(return_value, getThis());
+
+    xls_object *obj = Z_XLS_P(getThis());
+
+    outline_settings(&obj->write_ptr, visible, below, right, auto_style);
+}
+/* }}} */
+
 /** {{{ \Vtiful\Kernel\Excel::freezePanes(int $row, int $column)
  */
 PHP_METHOD(vtiful_xls, freezePanes)
@@ -1805,6 +1837,7 @@ zend_function_entry xls_methods[] = {
         PHP_ME(vtiful_xls, setCurrentLine,    xls_set_curr_line_arginfo,           ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, defaultFormat,     xls_set_global_format,               ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, defaultRowOptions, xls_set_default_row_options_arginfo, ZEND_ACC_PUBLIC)
+        PHP_ME(vtiful_xls, outlineSettings,   xls_set_outline_settings_arginfo,    ZEND_ACC_PUBLIC)
 
         PHP_ME(vtiful_xls, freezePanes,    xls_freeze_panes_arginfo,   ZEND_ACC_PUBLIC)
 

--- a/kernel/write.c
+++ b/kernel/write.c
@@ -451,6 +451,14 @@ void margins(xls_resource_write_t *res, double left, double right, double top, d
 }
 
 /*
+ * Set outline settings
+ */
+void outline_settings(xls_resource_write_t *res, uint8_t visible, uint8_t symbols_below, uint8_t symbols_right, uint8_t auto_style)
+{
+    worksheet_outline_settings(res->worksheet, visible, symbols_below, symbols_right, auto_style);
+}
+
+/*
  * Call finalization code and close file.
  */
 lxw_error

--- a/tests/outline_settings.phpt
+++ b/tests/outline_settings.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Check for vtiful presence
+--SKIPIF--
+<?php if (!extension_loaded("xlswriter")) print "skip"; ?>
+--FILE--
+<?php
+$config = ['path' => './tests'];
+$excel = new \Vtiful\Kernel\Excel($config);
+
+$excel->fileName('outline_settings.xlsx');
+
+$excel->outlineSettings(
+    /* visible */ true,
+    /* below */ false,
+    /* right */ false
+    /* autoStyle = false */
+);
+
+$filePath = $excel
+    ->header(['Region', 'Sales'])
+    ->data([
+        ['North', 1000], // row 2
+        ['North', 1200],
+        ['North', 900],
+        ['North', 1200],
+        ['North Total', 4300], // row 6
+        ['South', 400], // row 7
+        ['South', 600],
+        ['South', 500],
+        ['South', 600],
+        ['South Total', 2100], // row 11
+        ['Grand Total', 6400], // row 12
+        ['hidden row', 0],
+    ])
+    ->setRow('A1', 15, null)
+    ->setRow('A2:A5', 15, null, 2, false, true)
+    ->setRow('A6', 15, null, 1, true)
+    ->setRow('A7:A10', 15, null, 2)
+    ->setRow('A11', 15, null, 1)
+    ->setRow('A12', 15, null, 0)
+    ->setRow('A13', 15, null, null, null, true)
+    ->output();
+
+var_dump($filePath);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/outline_settings.xlsx');
+?>
+--EXPECT--
+string(29) "./tests/outline_settings.xlsx"


### PR DESCRIPTION
https://libxlsxwriter.github.io/worksheet_8h.html#a9efae5027e762c9a29f6afa547e4b2db

`below` - for row
`right` - for column

**In these two examples only the rows are outlined**

```php
$excel->outlineSettings(
    true, 
    false, // <-- below
    false
);
```

![1](https://github.com/user-attachments/assets/ffae89df-07ea-40b9-a852-da8b3bf844b1)

```php
$excel->outlineSettings(
    true, 
    true, // <-- below
    false
);
```

![2](https://github.com/user-attachments/assets/77235f8a-1746-4f4b-8752-e1e6cc167d6c)

**In Microsoft Excel these settings can be found (https://support.microsoft.com/en-us/office/outline-group-data-in-a-worksheet-08ce98c4-0063-4d42-8ac7-8278c49e9aff):**
![image](https://github.com/user-attachments/assets/08e26f9c-0ace-4e21-8194-90f387fc78d8)

