### PR TITLE
fix: Use worksheet_write_boolean for PHP boolean values

### DIFF
--- a/kernel/write.c
+++ b/kernel/write.c
@@ -74,7 +74,7 @@ void type_writer(zval *value, zend_long row, zend_long columns, xls_resource_wri
     }
 
     if (value_type == IS_TRUE || value_type == IS_FALSE) {
-        WORKSHEET_WRITER_EXCEPTION(worksheet_write_boolean(res->worksheet, lxw_row, lxw_col, zend_is_true(value), format_handle));
+        WORKSHEET_WRITER_EXCEPTION(worksheet_write_boolean(res->worksheet, (lxw_row_t)row, (lxw_col_t)columns, zend_is_true(value), format_handle));
         return;
     }
 }

--- a/kernel/write.c
+++ b/kernel/write.c
@@ -72,6 +72,11 @@ void type_writer(zval *value, zend_long row, zend_long columns, xls_resource_wri
         WORKSHEET_WRITER_EXCEPTION(worksheet_write_number(res->worksheet, (lxw_row_t)row, (lxw_col_t)columns, zval_get_double(value), NULL));
         return;
     }
+
+    if (value_type == IS_TRUE || value_type == IS_FALSE) {
+        WORKSHEET_WRITER_EXCEPTION(worksheet_write_boolean(res->worksheet, lxw_row, lxw_col, zend_is_true(value), format_handle));
+        return;
+    }
 }
 
 /*

--- a/tests/write_boolean.phpt
+++ b/tests/write_boolean.phpt
@@ -1,7 +1,10 @@
 --TEST--
-PHP bool values are written via worksheet_write_boolean (xlsx cell type "b")
+Check for vtiful presence
 --SKIPIF--
-<?php if (!extension_loaded("xlswriter")) print "skip"; ?>
+<?php
+if (!extension_loaded("xlswriter")) print "skip";
+if (!extension_loaded("zip")) print "skip zip extension required to inspect the xlsx";
+?>
 --FILE--
 <?php
 $config = ['path' => './tests'];
@@ -19,24 +22,23 @@ var_dump($filePath);
 
 /* Inspect the generated XML: bool cells must be t="b" with 1/0, not the
  * silent fall-through we got before the worksheet_write_boolean call. */
-$xml = "";
 $zip = new ZipArchive();
-if ($zip->open($filePath) === true) {
-    $xml = $zip->getFromName('xl/worksheets/sheet1.xml');
-    $zip->close();
-}
+$zip->open($filePath);
+$xml = $zip->getFromName('xl/worksheets/sheet1.xml');
+$zip->close();
+
 var_dump(strpos($xml, 't="b"') !== false);
-preg_match_all('/<c r="C2"[^>]*t="b"[^>]*>\s*<v>(\d)<\/v>/', $xml, $m1);
-preg_match_all('/<c r="C3"[^>]*t="b"[^>]*>\s*<v>(\d)<\/v>/', $xml, $m2);
-var_dump($m1[1][0] ?? null);
-var_dump($m2[1][0] ?? null);
+preg_match('/<c r="C2"[^>]*t="b"[^>]*>\s*<v>(\d)<\/v>/', $xml, $m1);
+preg_match('/<c r="C3"[^>]*t="b"[^>]*>\s*<v>(\d)<\/v>/', $xml, $m2);
+var_dump($m1[1] ?? null);
+var_dump($m2[1] ?? null);
 ?>
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/write_boolean.xlsx');
 ?>
---EXPECT--
-string(26) "./tests/write_boolean.xlsx"
+--EXPECTF--
+string(%d) "%swrite_boolean.xlsx"
 bool(true)
 string(1) "1"
 string(1) "0"

--- a/tests/write_boolean.phpt
+++ b/tests/write_boolean.phpt
@@ -1,0 +1,42 @@
+--TEST--
+PHP bool values are written via worksheet_write_boolean (xlsx cell type "b")
+--SKIPIF--
+<?php if (!extension_loaded("xlswriter")) print "skip"; ?>
+--FILE--
+<?php
+$config = ['path' => './tests'];
+$excel = new \Vtiful\Kernel\Excel($config);
+
+$filePath = $excel->fileName("write_boolean.xlsx")
+    ->header(['name', 'age', 'active'])
+    ->data([
+        ['viest', 21, true],
+        ['wjx',   21, false],
+    ])
+    ->output();
+
+var_dump($filePath);
+
+/* Inspect the generated XML: bool cells must be t="b" with 1/0, not the
+ * silent fall-through we got before the worksheet_write_boolean call. */
+$xml = "";
+$zip = new ZipArchive();
+if ($zip->open($filePath) === true) {
+    $xml = $zip->getFromName('xl/worksheets/sheet1.xml');
+    $zip->close();
+}
+var_dump(strpos($xml, 't="b"') !== false);
+preg_match_all('/<c r="C2"[^>]*t="b"[^>]*>\s*<v>(\d)<\/v>/', $xml, $m1);
+preg_match_all('/<c r="C3"[^>]*t="b"[^>]*>\s*<v>(\d)<\/v>/', $xml, $m2);
+var_dump($m1[1][0] ?? null);
+var_dump($m2[1][0] ?? null);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/write_boolean.xlsx');
+?>
+--EXPECT--
+string(26) "./tests/write_boolean.xlsx"
+bool(true)
+string(1) "1"
+string(1) "0"


### PR DESCRIPTION
When writing boolean values from PHP to Excel, they were not being parsed as such. This change uses libxlsxwriter's native boolean writer to properly display TRUE/FALSE in cells.