### PR TITLE
Update libxlsxwriter from 1.1.3 to 1.1.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "library/libxlsxwriter"]
 	path = library/libxlsxwriter
 	url = https://github.com/jmcnamara/libxlsxwriter.git
-	branch = RELEASE_1.0.0
+	branch = RELEASE_1.1.6
 [submodule "library/libexpat"]
 	path = library/libexpat
 	url = https://github.com/libexpat/libexpat.git


### PR DESCRIPTION
Closes https://github.com/viest/php-ext-xlswriter/issues/559.

- The bundled minizip in libxlsxwriter 1.1.3 uses a K&R (pre-ANSI) C function declaration in `mztools.c`
- PHP 8.5 compiles extensions with `-std=gnu23` (C23), which removed K&R declarations from the standard, causing a hard build error on macOS (Apple Clang defaults to C23 via Xcode 16+)
- This was fixed upstream in libxlsxwriter 1.1.6 (commit 957ed5c)
- v1.2.x was not used because it introduces API changes (`has_dynamic_arrays` removed from `lxw_worksheet`)