### PR TITLE
perf(reader): lazy metadata load + merge-follow index; memory-safety fixes

### DIFF
--- a/ide-helper/helper.php
+++ b/ide-helper/helper.php
@@ -318,6 +318,30 @@ class Excel
     }
 
     /**
+     * Auto-size columns to fit their content.
+     *
+     * Column widths are estimated from the content written so far (wide/CJK
+     * code points count as two columns) and applied to the active worksheet.
+     * The optional A1 range (e.g. "A:Z", "A1:J100") limits which columns are
+     * affected; omit it to size every column that received data. Estimates
+     * approximate Excel's own auto-fit, which depends on font metrics only
+     * the application knows.
+     *
+     * Call before output() and before switching sheets, since the per-sheet
+     * width tracking resets when the active worksheet changes.
+     *
+     * @param string|null $range
+     *
+     * @return Excel
+     *
+     * @author viest
+     */
+    public function autoSize(?string $range = NULL): self
+    {
+        return $this;
+    }
+
+    /**
      * Open xlsx file
      *
      * @param string $fileName

--- a/ide-helper/helper.php
+++ b/ide-helper/helper.php
@@ -318,17 +318,20 @@ class Excel
     }
 
     /**
-     * Auto-size columns to fit their content.
+     * Enable automatic column-width sizing for the active worksheet.
      *
-     * Column widths are estimated from the content written so far (wide/CJK
-     * code points count as two columns) and applied to the active worksheet.
-     * The optional A1 range (e.g. "A:Z", "A1:J100") limits which columns are
-     * affected; omit it to size every column that received data. Estimates
-     * approximate Excel's own auto-fit, which depends on font metrics only
-     * the application knows.
+     * Once enabled, every subsequently written cell contributes its display
+     * width to a per-column maximum; the tracked widths are applied at
+     * output() time (and flushed when switching sheets). So call autoSize()
+     * BEFORE the writes it should track. Tracking is off by default, so
+     * scripts that never call autoSize() pay no per-cell cost.
      *
-     * Call before output() and before switching sheets, since the per-sheet
-     * width tracking resets when the active worksheet changes.
+     * The optional A1 range (e.g. "A:Z", "A1:J100") restricts which columns
+     * are sized; omit it to size every column that received data. Widths are
+     * estimates from character counts (wide/CJK code points count as two);
+     * they approximate but cannot exactly match Excel's own auto-fit, which
+     * depends on font metrics only the application knows. Widths are clamped
+     * to Excel's maximum of 255.
      *
      * @param string|null $range
      *

--- a/include/xlswriter.h
+++ b/include/xlswriter.h
@@ -95,7 +95,18 @@ enum xlswirter_printed_direction {
 typedef struct {
     lxw_workbook  *workbook;
     lxw_worksheet *worksheet;
+    /* Auto-size tracking: per-column maximum estimated display width,
+     * accumulated during writes so Excel::autoSize() can apply them.
+     * Lazily allocated on first tracked write; reset on sheet switch. */
+    double        *auto_widths;
+    size_t         auto_widths_n;
 } xls_resource_write_t;
+
+/* Auto-size helpers (forward declarations — defined in kernel/write.c). */
+double xls_estimate_cell_width(zval *value);
+void   xls_track_auto_width(xls_resource_write_t *res, lxw_col_t col, double width);
+void   xls_auto_widths_reset(xls_resource_write_t *res);
+void   xls_auto_widths_apply(xls_resource_write_t *res, lxw_col_t first_col, lxw_col_t last_col);
 
 typedef struct {
     lxw_format  *format;
@@ -375,6 +386,8 @@ static inline void php_vtiful_close_resource(zend_object *obj) {
         lxw_workbook_free(intern->write_ptr.workbook);
         intern->write_ptr.workbook = NULL;
     }
+
+    xls_auto_widths_reset(&intern->write_ptr);
 
     if (intern->format_ptr.format != NULL) {
         intern->format_ptr.format = NULL;

--- a/include/xlswriter.h
+++ b/include/xlswriter.h
@@ -96,10 +96,14 @@ typedef struct {
     lxw_workbook  *workbook;
     lxw_worksheet *worksheet;
     /* Auto-size tracking: per-column maximum estimated display width,
-     * accumulated during writes so Excel::autoSize() can apply them.
-     * Lazily allocated on first tracked write; reset on sheet switch. */
+     * accumulated during writes (only while auto_size_enabled) so the widths
+     * can be applied before the worksheet is packaged. Lazily allocated on
+     * first tracked write; reset on sheet switch. */
     double        *auto_widths;
     size_t         auto_widths_n;
+    int            auto_size_enabled;
+    lxw_col_t      auto_size_first_col;
+    lxw_col_t      auto_size_last_col;
 } xls_resource_write_t;
 
 /* Auto-size helpers (forward declarations — defined in kernel/write.c). */
@@ -107,6 +111,7 @@ double xls_estimate_cell_width(zval *value);
 void   xls_track_auto_width(xls_resource_write_t *res, lxw_col_t col, double width);
 void   xls_auto_widths_reset(xls_resource_write_t *res);
 void   xls_auto_widths_apply(xls_resource_write_t *res, lxw_col_t first_col, lxw_col_t last_col);
+void   xls_auto_widths_flush(xls_resource_write_t *res);
 
 typedef struct {
     lxw_format  *format;

--- a/kernel/excel.c
+++ b/kernel/excel.c
@@ -243,6 +243,10 @@ ZEND_BEGIN_ARG_INFO_EX(xls_set_curr_line_arginfo, 0, 0, 1)
                 ZEND_ARG_INFO(0, row)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(xls_auto_size_arginfo, 0, 0, 0)
+                ZEND_ARG_INFO(0, range)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(xls_get_curr_line_arginfo, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -653,6 +657,9 @@ PHP_METHOD(vtiful_xls, addSheet)
         sheet_name = ZSTR_VAL(zs_sheet_name);
     }
 
+    /* Per-sheet auto-size tracking starts fresh for the new sheet. */
+    xls_auto_widths_reset(&obj->write_ptr);
+
     obj->write_ptr.worksheet = workbook_add_worksheet(obj->write_ptr.workbook, sheet_name);
 }
 /* }}} */
@@ -714,6 +721,9 @@ PHP_METHOD(vtiful_xls, checkoutSheet)
     }
 
     SHEET_LINE_SET(obj, line);
+
+    /* Per-sheet auto-size tracking starts fresh for the switched sheet. */
+    xls_auto_widths_reset(&obj->write_ptr);
 
     obj->write_ptr.worksheet = sheet_t;
 }
@@ -1480,6 +1490,47 @@ PHP_METHOD(vtiful_xls, setRow)
     } else {
         set_row(range, height, &obj->write_ptr, NULL, options);
     }
+}
+/* }}} */
+
+/** {{{ \Vtiful\Kernel\Excel::autoSize([string $range])
+ *  Sizes columns to fit their content. While cells are written the extension
+ *  tracks the widest value per column; autoSize() applies those widths to the
+ *  current worksheet. The optional A1 range (e.g. "A:Z", "A1:J100") limits
+ *  which columns are affected — omit it to size every column that received
+ *  data. Widths are estimates from character counts (wide/CJK code points
+ *  count as 2); they approximate but cannot exactly match Excel's own
+ *  auto-fit, which depends on font metrics only the application knows.
+ *  Call before output() and before switching sheets, since the per-sheet
+ *  tracking resets when the active worksheet changes.
+ */
+PHP_METHOD(vtiful_xls, autoSize)
+{
+    zend_string *range = NULL;
+    lxw_col_t    first_col = 0, last_col = 0;
+
+    ZEND_PARSE_PARAMETERS_START(0, 1)
+            Z_PARAM_OPTIONAL
+            Z_PARAM_STR_OR_NULL(range)
+    ZEND_PARSE_PARAMETERS_END();
+
+    ZVAL_COPY(return_value, getThis());
+
+    xls_object *obj = Z_XLS_P(getThis());
+
+    WORKSHEET_NOT_INITIALIZED(obj);
+
+    if (range != NULL && ZSTR_LEN(range) > 0) {
+        first_col = lxw_name_to_col(ZSTR_VAL(range));
+        last_col  = lxw_name_to_col_2(ZSTR_VAL(range));
+        if (last_col < first_col) last_col = first_col;
+        if (last_col >= LXW_COL_MAX) last_col = LXW_COL_MAX - 1;
+    } else {
+        first_col = 0;
+        last_col  = LXW_COL_MAX - 1;
+    }
+
+    xls_auto_widths_apply(&obj->write_ptr, first_col, last_col);
 }
 /* }}} */
 
@@ -3997,6 +4048,7 @@ zend_function_entry xls_methods[] = {
         PHP_ME(vtiful_xls, mergeCells,        xls_merge_cells_arginfo,             ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, setColumn,         xls_set_column_arginfo,              ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, setRow,            xls_set_row_arginfo,                 ZEND_ACC_PUBLIC)
+        PHP_ME(vtiful_xls, autoSize,          xls_auto_size_arginfo,               ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, getCurrentLine,    xls_get_curr_line_arginfo,           ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, setCurrentLine,    xls_set_curr_line_arginfo,           ZEND_ACC_PUBLIC)
         PHP_ME(vtiful_xls, defaultFormat,     xls_set_global_format,               ZEND_ACC_PUBLIC)

--- a/kernel/excel.c
+++ b/kernel/excel.c
@@ -3530,6 +3530,12 @@ PHP_METHOD(vtiful_xls, nextRowWithFormula)
         RETURN_NULL();
     }
 
+    /* nextRowWithFormula surfaces per-cell hyperlink URLs, which live in
+     * sheet metadata. Trigger a lazy metadata load now, while the data zip
+     * entry is still closed (minizip allows only one open entry at a time,
+     * so loading mid-stream would be declined). */
+    lxr_worksheet_hyperlink_count(obj->read_ptr.sheet_t);
+
     if (!sheet_read_row(obj->read_ptr.sheet_t)) {
         RETURN_NULL();
     }

--- a/kernel/excel.c
+++ b/kernel/excel.c
@@ -657,7 +657,9 @@ PHP_METHOD(vtiful_xls, addSheet)
         sheet_name = ZSTR_VAL(zs_sheet_name);
     }
 
-    /* Per-sheet auto-size tracking starts fresh for the new sheet. */
+    /* Flush auto-size widths to the sheet being left, then reset tracking for
+     * the new sheet. */
+    xls_auto_widths_flush(&obj->write_ptr);
     xls_auto_widths_reset(&obj->write_ptr);
 
     obj->write_ptr.worksheet = workbook_add_worksheet(obj->write_ptr.workbook, sheet_name);
@@ -722,7 +724,8 @@ PHP_METHOD(vtiful_xls, checkoutSheet)
 
     SHEET_LINE_SET(obj, line);
 
-    /* Per-sheet auto-size tracking starts fresh for the switched sheet. */
+    /* Flush auto-size widths to the sheet being left, then reset tracking. */
+    xls_auto_widths_flush(&obj->write_ptr);
     xls_auto_widths_reset(&obj->write_ptr);
 
     obj->write_ptr.worksheet = sheet_t;
@@ -958,6 +961,9 @@ PHP_METHOD(vtiful_xls, output)
     xls_object *obj = Z_XLS_P(getThis());
 
     WORKBOOK_NOT_INITIALIZED(obj);
+
+    /* Apply any tracked auto-size widths before the workbook is packaged. */
+    xls_auto_widths_flush(&obj->write_ptr);
 
     workbook_file(&obj->write_ptr);
 
@@ -1494,20 +1500,19 @@ PHP_METHOD(vtiful_xls, setRow)
 /* }}} */
 
 /** {{{ \Vtiful\Kernel\Excel::autoSize([string $range])
- *  Sizes columns to fit their content. While cells are written the extension
- *  tracks the widest value per column; autoSize() applies those widths to the
- *  current worksheet. The optional A1 range (e.g. "A:Z", "A1:J100") limits
- *  which columns are affected — omit it to size every column that received
- *  data. Widths are estimates from character counts (wide/CJK code points
- *  count as 2); they approximate but cannot exactly match Excel's own
- *  auto-fit, which depends on font metrics only the application knows.
- *  Call before output() and before switching sheets, since the per-sheet
- *  tracking resets when the active worksheet changes.
+ *  Enables automatic column-width sizing for the active worksheet and
+ *  (optionally) restricts it to an A1 range such as "A:Z" or "A1:J100".
+ *  From this point on every written cell contributes its display width to a
+ *  per-column maximum; the tracked widths are applied to the worksheet at
+ *  output() time (and flushed when switching sheets). Call autoSize() BEFORE
+ *  writing the data it should size, otherwise the writes are not tracked.
+ *  Widths are estimates from character counts (wide/CJK code points count as
+ *  2); they approximate but cannot exactly match Excel's own auto-fit, which
+ *  depends on font metrics only the application knows.
  */
 PHP_METHOD(vtiful_xls, autoSize)
 {
     zend_string *range = NULL;
-    lxw_col_t    first_col = 0, last_col = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
             Z_PARAM_OPTIONAL
@@ -1518,19 +1523,20 @@ PHP_METHOD(vtiful_xls, autoSize)
 
     xls_object *obj = Z_XLS_P(getThis());
 
-    WORKSHEET_NOT_INITIALIZED(obj);
+    WORKBOOK_NOT_INITIALIZED(obj);
 
+    obj->write_ptr.auto_size_enabled = 1;
     if (range != NULL && ZSTR_LEN(range) > 0) {
-        first_col = lxw_name_to_col(ZSTR_VAL(range));
-        last_col  = lxw_name_to_col_2(ZSTR_VAL(range));
-        if (last_col < first_col) last_col = first_col;
-        if (last_col >= LXW_COL_MAX) last_col = LXW_COL_MAX - 1;
+        obj->write_ptr.auto_size_first_col = lxw_name_to_col(ZSTR_VAL(range));
+        obj->write_ptr.auto_size_last_col  = lxw_name_to_col_2(ZSTR_VAL(range));
+        if (obj->write_ptr.auto_size_last_col < obj->write_ptr.auto_size_first_col)
+            obj->write_ptr.auto_size_last_col = obj->write_ptr.auto_size_first_col;
+        if (obj->write_ptr.auto_size_last_col >= LXW_COL_MAX)
+            obj->write_ptr.auto_size_last_col = LXW_COL_MAX - 1;
     } else {
-        first_col = 0;
-        last_col  = LXW_COL_MAX - 1;
+        obj->write_ptr.auto_size_first_col = 0;
+        obj->write_ptr.auto_size_last_col  = LXW_COL_MAX - 1;
     }
-
-    xls_auto_widths_apply(&obj->write_ptr, first_col, last_col);
 }
 /* }}} */
 

--- a/kernel/write.c
+++ b/kernel/write.c
@@ -12,6 +12,140 @@
 
 #include "xlswriter.h"
 
+/* ------------------------------------------------------------------------- */
+/* Auto-size width estimation                                                */
+/* ------------------------------------------------------------------------- */
+
+/* Returns 1 when the Unicode codepoint is East-Asian Wide/Fullwidth (counts
+ * as 2 display columns), 0 otherwise. Covers the common CJK/Hangul/fullwidth
+ * and emoji ranges; not exhaustive but matches Excel's auto-fit closely
+ * enough for typical content. */
+static int xls_codepoint_is_wide(uint32_t cp)
+{
+    if (cp < 0x1100) return 0;
+    if (cp <= 0x115F) return 1;                       /* Hangul Jamo */
+    if (cp == 0x2329 || cp == 0x232A) return 1;
+    if (cp >= 0x2E80 && cp <= 0x303E) return 1;       /* CJK radicals */
+    if (cp >= 0x3041 && cp <= 0x33FF) return 1;       /* Hiragana/Katakana/CJK */
+    if (cp >= 0x3400 && cp <= 0x4DBF) return 1;       /* CJK Ext A */
+    if (cp >= 0x4E00 && cp <= 0x9FFF) return 1;       /* CJK Unified */
+    if (cp >= 0xA000 && cp <= 0xA4CF) return 1;       /* Yi */
+    if (cp >= 0xAC00 && cp <= 0xD7A3) return 1;       /* Hangul Syllables */
+    if (cp >= 0xF900 && cp <= 0xFAFF) return 1;       /* CJK Compat */
+    if (cp >= 0xFE10 && cp <= 0xFE19) return 1;       /* Vertical forms */
+    if (cp >= 0xFE30 && cp <= 0xFE6F) return 1;       /* CJK Compat Forms */
+    if (cp >= 0xFF00 && cp <= 0xFF60) return 1;       /* Fullwidth Forms */
+    if (cp >= 0xFFE0 && cp <= 0xFFE6) return 1;       /* Fullwidth signs */
+    if (cp >= 0x1F300 && cp <= 0x1FAFF) return 1;     /* Emoji / symbols */
+    if (cp >= 0x20000 && cp <= 0x3FFFD) return 1;     /* CJK Ext B+ */
+    return 0;
+}
+
+/* Decode one UTF-8 sequence from str[*pos]; advance *pos and store the
+ * codepoint. Returns 0 on success, -1 on invalid/truncated input. */
+static int utf8_next(const unsigned char *str, size_t len, size_t *pos, uint32_t *cp)
+{
+    size_t i = *pos;
+    unsigned char c = str[i];
+    if (c < 0x80) { *cp = c; *pos = i + 1; return 0; }
+    if ((c & 0xE0) == 0xC0 && i + 1 < len) {
+        *cp = ((uint32_t)(c & 0x1F) << 6) | (str[i + 1] & 0x3F);
+        *pos = i + 2; return 0;
+    }
+    if ((c & 0xF0) == 0xE0 && i + 2 < len) {
+        *cp = ((uint32_t)(c & 0x0F) << 12) | ((uint32_t)(str[i + 1] & 0x3F) << 6) | (str[i + 2] & 0x3F);
+        *pos = i + 3; return 0;
+    }
+    if ((c & 0xF8) == 0xF0 && i + 3 < len) {
+        *cp = ((uint32_t)(c & 0x07) << 18) | ((uint32_t)(str[i + 1] & 0x3F) << 12)
+            | ((uint32_t)(str[i + 2] & 0x3F) << 6) | (str[i + 3] & 0x3F);
+        *pos = i + 4; return 0;
+    }
+    /* Invalid/overlong/truncated: treat as a single narrow byte. */
+    *cp = c; *pos = i + 1; return -1;
+}
+
+/* Sum display columns over a UTF-8 string (wide codepoints count as 2). */
+static double utf8_display_width(const char *s, size_t len)
+{
+    const unsigned char *str = (const unsigned char *)s;
+    size_t pos = 0;
+    double width = 0;
+    while (pos < len) {
+        uint32_t cp;
+        utf8_next(str, len, &pos, &cp);
+        width += xls_codepoint_is_wide(cp) ? 2 : 1;
+    }
+    return width;
+}
+
+/* Estimate a cell's display width in Excel column-width units. Converts the
+ * value to its string form and measures it (wide/CJK codepoints count as 2).
+ * No extra margin is added: libxlsxwriter already bakes in Excel's standard
+ * column margin (~0.71) when the width is written, which matches what
+ * Excel's own auto-fit produces. */
+double xls_estimate_cell_width(zval *value)
+{
+    zend_string *s;
+    double width;
+
+    if (value == NULL || Z_TYPE_P(value) == IS_NULL) return 0.0;
+
+    s = zval_get_string(value);
+    width = utf8_display_width(ZSTR_VAL(s), ZSTR_LEN(s));
+    zend_string_release(s);
+
+    return width;
+}
+
+/* Grow the per-column width map to cover `col` and keep the max. */
+void xls_track_auto_width(xls_resource_write_t *res, lxw_col_t col, double width)
+{
+    size_t need, i;
+    double *grown;
+
+    if (res == NULL || col >= LXW_COL_MAX || width <= 0.0) return;
+
+    if (res->auto_widths == NULL) {
+        need = (size_t)col + 1;
+        if (need < 16) need = 16;
+        res->auto_widths = (double *)ecalloc(need, sizeof(double));
+        res->auto_widths_n = need;
+    } else if ((size_t)col >= res->auto_widths_n) {
+        need = res->auto_widths_n;
+        while (need <= (size_t)col) need *= 2;
+        grown = (double *)erealloc(res->auto_widths, need * sizeof(double));
+        for (i = res->auto_widths_n; i < need; i++) grown[i] = 0.0;
+        res->auto_widths = grown;
+        res->auto_widths_n = need;
+    }
+
+    if (width > res->auto_widths[col]) res->auto_widths[col] = width;
+}
+
+void xls_auto_widths_reset(xls_resource_write_t *res)
+{
+    if (res == NULL || res->auto_widths == NULL) return;
+    efree(res->auto_widths);
+    res->auto_widths = NULL;
+    res->auto_widths_n = 0;
+}
+
+/* Apply the tracked per-column widths to [first_col, last_col] on the active
+ * worksheet. Columns with no tracked content keep their existing width. */
+void xls_auto_widths_apply(xls_resource_write_t *res, lxw_col_t first_col, lxw_col_t last_col)
+{
+    lxw_col_t c;
+    if (res == NULL || res->auto_widths == NULL) return;
+    if (first_col > last_col) { lxw_col_t t = first_col; first_col = last_col; last_col = t; }
+    for (c = first_col; c <= last_col; c++) {
+        if (c >= res->auto_widths_n) break;
+        if (res->auto_widths[c] > 0.0) {
+            worksheet_set_column_opt(res->worksheet, c, c, res->auto_widths[c], NULL, NULL);
+        }
+    }
+}
+
 /*
  * According to the zval type written to the file
  */
@@ -23,6 +157,9 @@ void type_writer(zval *value, zend_long row, zend_long columns, xls_resource_wri
     lxw_row_t lxw_row = (lxw_row_t)row;
 
     zend_uchar value_type = Z_TYPE_P(value);
+
+    /* Track the cell's display width for autoSize(), independent of type. */
+    xls_track_auto_width(res, lxw_col, xls_estimate_cell_width(value));
 
     if (value_type == IS_STRING) {
         zend_string *_zs_value = zval_get_string(value);

--- a/kernel/write.c
+++ b/kernel/write.c
@@ -81,9 +81,11 @@ static double utf8_display_width(const char *s, size_t len)
 
 /* Estimate a cell's display width in Excel column-width units. Converts the
  * value to its string form and measures it (wide/CJK codepoints count as 2).
- * No extra margin is added: libxlsxwriter already bakes in Excel's standard
- * column margin (~0.71) when the width is written, which matches what
- * Excel's own auto-fit produces. */
+ * Clamped to Excel's maximum column width (255). No extra margin is added:
+ * libxlsxwriter already bakes in Excel's standard column margin (~0.71) when
+ * the width is written, which matches what Excel's own auto-fit produces. */
+#define LXW_MAX_COL_WIDTH 255.0
+
 double xls_estimate_cell_width(zval *value)
 {
     zend_string *s;
@@ -95,6 +97,7 @@ double xls_estimate_cell_width(zval *value)
     width = utf8_display_width(ZSTR_VAL(s), ZSTR_LEN(s));
     zend_string_release(s);
 
+    if (width > LXW_MAX_COL_WIDTH) width = LXW_MAX_COL_WIDTH;
     return width;
 }
 
@@ -132,18 +135,36 @@ void xls_auto_widths_reset(xls_resource_write_t *res)
 }
 
 /* Apply the tracked per-column widths to [first_col, last_col] on the active
- * worksheet. Columns with no tracked content keep their existing width. */
+ * worksheet. Columns with no tracked content keep their existing width. A
+ * set_column failure (e.g. optimize-mode index conflict) is surfaced as a
+ * warning rather than silently dropped. */
 void xls_auto_widths_apply(xls_resource_write_t *res, lxw_col_t first_col, lxw_col_t last_col)
 {
     lxw_col_t c;
-    if (res == NULL || res->auto_widths == NULL) return;
+    if (res == NULL || res->auto_widths == NULL || res->worksheet == NULL) return;
     if (first_col > last_col) { lxw_col_t t = first_col; first_col = last_col; last_col = t; }
     for (c = first_col; c <= last_col; c++) {
         if (c >= res->auto_widths_n) break;
         if (res->auto_widths[c] > 0.0) {
-            worksheet_set_column_opt(res->worksheet, c, c, res->auto_widths[c], NULL, NULL);
+            lxw_error err = worksheet_set_column_opt(res->worksheet, c, c,
+                                                     res->auto_widths[c], NULL, NULL);
+            if (err != LXW_NO_ERROR) {
+                php_error_docref(NULL, E_WARNING,
+                    "autoSize: could not set column %u width (%s)",
+                    (unsigned)(c + 1), lxw_strerror(err));
+            }
         }
     }
+}
+
+/* Apply the tracked widths for the configured range to the active worksheet,
+ * then clear the per-column map (the enable flag survives so the next sheet
+ * keeps tracking). Called at output() and on sheet switch. */
+void xls_auto_widths_flush(xls_resource_write_t *res)
+{
+    if (res == NULL || !res->auto_size_enabled) return;
+    xls_auto_widths_apply(res, res->auto_size_first_col, res->auto_size_last_col);
+    xls_auto_widths_reset(res);
 }
 
 /*
@@ -158,8 +179,11 @@ void type_writer(zval *value, zend_long row, zend_long columns, xls_resource_wri
 
     zend_uchar value_type = Z_TYPE_P(value);
 
-    /* Track the cell's display width for autoSize(), independent of type. */
-    xls_track_auto_width(res, lxw_col, xls_estimate_cell_width(value));
+    /* Track the cell's display width for autoSize() — only when the user
+     * has opted in, so writes pay no cost otherwise. */
+    if (res->auto_size_enabled) {
+        xls_track_auto_width(res, lxw_col, xls_estimate_cell_width(value));
+    }
 
     if (value_type == IS_STRING) {
         zend_string *_zs_value = zval_get_string(value);

--- a/library/libxlsxreader/include/xlsxreader/worksheet.h
+++ b/library/libxlsxreader/include/xlsxreader/worksheet.h
@@ -38,7 +38,7 @@ int    lxr_worksheet_merged_get  (const lxr_worksheet *ws, size_t idx,
 /* Returns 1 when (row, col) (1-based) lies inside a merged range and is NOT
  * the merge's master cell; 0 otherwise. Useful for honoring
  * LXR_SKIP_MERGED_FOLLOW in row-shaped readers. */
-int lxr_worksheet_in_merge_follow(const lxr_worksheet *ws, size_t row, size_t col);
+int lxr_worksheet_in_merge_follow(lxr_worksheet *ws, size_t row, size_t col);
 
 /* Hyperlinks. The url/tooltip/display/location pointers (if non-NULL) are
  * owned by the worksheet and remain valid until lxr_worksheet_close().

--- a/library/libxlsxreader/src/lxr_internal.h
+++ b/library/libxlsxreader/src/lxr_internal.h
@@ -339,8 +339,10 @@ struct lxr_worksheet {
 
     int             eof;
 
-    /* Phase 1 metadata cache (eager, populated at open time). */
+    /* Phase 1 metadata cache (lazy, populated on first access). */
     lxr_worksheet_meta meta;
+    int                meta_loaded;
+    int                data_opened;
 
     /* Merge-follow index: merges re-indexed by last_row for amortised
      * near-O(1) point-in-range queries during sequential row scans.
@@ -357,6 +359,15 @@ lxr_error lxr_worksheet_open_internal(lxr_workbook *wb,
                                       const char *target_path,
                                       uint32_t flags,
                                       lxr_worksheet **out);
+
+/* Lazily load worksheet metadata on first access. Declared const because the
+ * metadata cache is logically a lazy memo: callers hold a const worksheet*,
+ * but the underlying object is heap-allocated and mutable. */
+lxr_error lxr_worksheet_ensure_meta(const lxr_worksheet *ws);
+
+/* Open the data zip entry + XML pump on first data read. If the worksheet
+ * uses merge-follow, metadata is loaded first (single-entry constraint). */
+lxr_error lxr_worksheet_ensure_data_open(lxr_worksheet *ws);
 
 /* worksheet_meta.c */
 lxr_error lxr_worksheet_meta_load(lxr_worksheet *ws);

--- a/library/libxlsxreader/src/lxr_internal.h
+++ b/library/libxlsxreader/src/lxr_internal.h
@@ -341,6 +341,15 @@ struct lxr_worksheet {
 
     /* Phase 1 metadata cache (eager, populated at open time). */
     lxr_worksheet_meta meta;
+
+    /* Merge-follow index: merges re-indexed by last_row for amortised
+     * near-O(1) point-in-range queries during sequential row scans.
+     * Built lazily on the first in_merge_follow() call. merge_order[i]
+     * is an index into meta.merges, sorted by ascending last_row. */
+    size_t         *merge_order;
+    size_t          merge_cursor;
+    size_t          merge_last_row;
+    int             merge_index_built;
 };
 
 /* worksheet.c */

--- a/library/libxlsxreader/src/worksheet.c
+++ b/library/libxlsxreader/src/worksheet.c
@@ -566,8 +566,14 @@ static lxr_error open_internal(lxr_workbook *wb, const char *target,
                                uint32_t flags, lxr_worksheet **out)
 {
     lxr_worksheet *ws;
-    lxr_error      rc;
     if (!wb || !target || !out) return LXR_ERROR_NULL_PARAMETER;
+
+    /* Validate the entry exists up front (cheap locate, no open) so that a
+     * bad path still fails at open time. The data stream and metadata are
+     * loaded lazily — see ensure_data_open / lxr_worksheet_ensure_meta. */
+    if (!lxr_zip_entry_exists(wb->zip, target)) {
+        return LXR_ERROR_ZIP_ENTRY_NOT_FOUND;
+    }
 
     ws = (lxr_worksheet *)calloc(1, sizeof(*ws));
     if (!ws) return LXR_ERROR_MEMORY_MALLOC_FAILED;
@@ -578,36 +584,69 @@ static lxr_error open_internal(lxr_workbook *wb, const char *target,
     ws->target_path = strdup(target);
     if (!ws->target_path) { free(ws); return LXR_ERROR_MEMORY_MALLOC_FAILED; }
 
-    /* Eagerly scan worksheet-level metadata before opening the streaming
-     * pump. Only one minizip entry can be open at a time, so the meta pass
-     * uses its own open/close cycle. */
-    rc = lxr_worksheet_meta_load(ws);
-    if (rc != LXR_NO_ERROR) {
-        lxr_worksheet_meta_free(&ws->meta);
-        free(ws->target_path);
-        free(ws);
-        return rc;
+    *out = ws;
+    return LXR_NO_ERROR;
+}
+
+/* Lazily load worksheet metadata. minizip allows only one open entry at a
+ * time, so the metadata pass cannot run while the data stream holds the
+ * entry. If data is mid-stream we leave metadata unloaded (accessors return
+ * empty); callers that need metadata during reads must trigger a load before
+ * the first data read. When the data pump has reached EOF we may safely
+ * reclaim the entry. */
+lxr_error lxr_worksheet_ensure_meta(const lxr_worksheet *ws_c)
+{
+    lxr_worksheet *ws = (lxr_worksheet *)ws_c;
+    lxr_error      rc;
+
+    if (!ws) return LXR_ERROR_NULL_PARAMETER;
+    if (ws->meta_loaded) return LXR_NO_ERROR;
+
+    /* Data stream active and not exhausted: loading now would require
+     * tearing down the pump mid-row, losing unread cells. Decline; metadata
+     * accessors will see an empty cache. */
+    if (ws->data_opened && ws->pump && !lxr_xml_pump_is_eof(ws->pump)) {
+        return LXR_NO_ERROR;
     }
 
-    ws->zf = lxr_zip_open_entry(wb->zip, target);
-    if (!ws->zf) {
-        lxr_worksheet_meta_free(&ws->meta);
-        free(ws->target_path);
-        free(ws);
-        return LXR_ERROR_ZIP_ENTRY_NOT_FOUND;
+    /* Reclaim the entry if the data pump is done (or never started). */
+    if (ws->data_opened) {
+        if (ws->pump) { lxr_xml_pump_destroy(ws->pump); ws->pump = NULL; }
+        if (ws->zf)   { lxr_zip_close_entry(ws->zf);    ws->zf = NULL; }
+        ws->data_opened = 0;
     }
+
+    rc = lxr_worksheet_meta_load(ws);
+    if (rc != LXR_NO_ERROR) return rc;
+    ws->meta_loaded = 1;
+    return LXR_NO_ERROR;
+}
+
+/* Open the data entry + pump on first use. Callers must route every data
+ * read through this so the entry is ready. */
+lxr_error lxr_worksheet_ensure_data_open(lxr_worksheet *ws)
+{
+    if (!ws) return LXR_ERROR_NULL_PARAMETER;
+    if (ws->data_opened) return LXR_NO_ERROR;
+
+    /* Merge-follow queries hit metadata during streaming; it must be loaded
+     * before the data entry opens (single minizip entry constraint). */
+    if (ws->flags & LXR_SKIP_MERGED_FOLLOW) {
+        lxr_error rc = lxr_worksheet_ensure_meta(ws);
+        if (rc != LXR_NO_ERROR) return rc;
+    }
+
+    ws->zf = lxr_zip_open_entry(ws->wb->zip, ws->target_path);
+    if (!ws->zf) return LXR_ERROR_ZIP_ENTRY_NOT_FOUND;
 
     ws->pump = lxr_xml_pump_create_zip_file(ws->zf);
     if (!ws->pump) {
         lxr_zip_close_entry(ws->zf);
-        lxr_worksheet_meta_free(&ws->meta);
-        free(ws->target_path);
-        free(ws);
+        ws->zf = NULL;
         return LXR_ERROR_MEMORY_MALLOC_FAILED;
     }
     lxr_xml_pump_set_handlers(ws->pump, on_start, on_end, on_text, ws);
-
-    *out = ws;
+    ws->data_opened = 1;
     return LXR_NO_ERROR;
 }
 
@@ -666,7 +705,11 @@ static lxr_error drive(lxr_worksheet *ws)
 
 lxr_error lxr_worksheet_next_row(lxr_worksheet *ws)
 {
+    lxr_error rc;
     if (!ws) return LXR_ERROR_NULL_PARAMETER;
+
+    rc = lxr_worksheet_ensure_data_open(ws);
+    if (rc != LXR_NO_ERROR) return rc;
 
     /* Drain anything left from a previous row by calling next_cell until it
      * returns END_OF_DATA. next_cell uses the suspend mechanism, so the pump
@@ -683,7 +726,7 @@ lxr_error lxr_worksheet_next_row(lxr_worksheet *ws)
     ws->pull_mode         = LXR_WS_PULL_ROW;
 
     while (!ws->pending_row_start && !ws->eof) {
-        lxr_error rc = drive(ws);
+        rc = drive(ws);
         if (rc != LXR_NO_ERROR) {
             ws->pull_mode = LXR_WS_PULL_NONE;
             return rc;
@@ -752,7 +795,11 @@ lxr_error lxr_worksheet_process(lxr_worksheet *ws,
                                 lxr_row_end_cb row_cb,
                                 void          *userdata)
 {
+    lxr_error rc;
     if (!ws) return LXR_ERROR_NULL_PARAMETER;
+
+    rc = lxr_worksheet_ensure_data_open(ws);
+    if (rc != LXR_NO_ERROR) return rc;
 
     ws->pull_mode      = LXR_WS_PULL_NONE;
     ws->user_cell_cb   = cell_cb;
@@ -761,7 +808,7 @@ lxr_error lxr_worksheet_process(lxr_worksheet *ws,
     ws->callback_stop  = 0;
 
     while (!ws->eof && !ws->callback_stop) {
-        lxr_error rc = drive(ws);
+        rc = drive(ws);
         if (rc != LXR_NO_ERROR) {
             ws->user_cell_cb = NULL;
             ws->user_row_cb  = NULL;

--- a/library/libxlsxreader/src/worksheet.c
+++ b/library/libxlsxreader/src/worksheet.c
@@ -623,6 +623,7 @@ void lxr_worksheet_close(lxr_worksheet *ws)
     if (ws->pump) lxr_xml_pump_destroy(ws->pump);
     if (ws->zf)   lxr_zip_close_entry(ws->zf);
     lxr_worksheet_meta_free(&ws->meta);
+    free(ws->merge_order);
     free(ws->cell_value);
     free(ws->cell_formula);
     free(ws->cell_inline);

--- a/library/libxlsxreader/src/worksheet_meta.c
+++ b/library/libxlsxreader/src/worksheet_meta.c
@@ -1054,12 +1054,80 @@ int lxr_worksheet_merged_get(const lxr_worksheet *ws, size_t idx, lxr_range *out
     return 1;
 }
 
-int lxr_worksheet_in_merge_follow(const lxr_worksheet *ws, size_t row, size_t col)
+/* Comparator for the merge_key array used to build merge_order. */
+struct merge_key { size_t idx; size_t last_row; };
+static int merge_key_cmp(const void *a, const void *b)
 {
-    size_t i;
+    size_t la = ((const struct merge_key *)a)->last_row;
+    size_t lb = ((const struct merge_key *)b)->last_row;
+    if (la < lb) return -1;
+    if (la > lb) return 1;
+    return 0;
+}
+
+/* Build merge_order: indices into meta.merges sorted by ascending last_row.
+ * Uses a merge_key array so the qsort comparator is self-contained
+ * (qsort_r is not portable across glibc/BSD/MSVC). On OOM the index is left
+ * NULL and in_merge_follow falls back to a plain linear scan. */
+static void build_merge_index(lxr_worksheet *ws)
+{
+    size_t n = ws->meta.merges_count;
+
+    ws->merge_index_built = 1;
+    ws->merge_order       = NULL;
+    ws->merge_cursor      = 0;
+    ws->merge_last_row    = 0;
+    if (n == 0) return;
+
+    struct merge_key *keys = (struct merge_key *)malloc(n * sizeof(*keys));
+    if (!keys) return;
+    for (size_t i = 0; i < n; i++) {
+        keys[i].idx      = i;
+        keys[i].last_row = ws->meta.merges[i].last_row;
+    }
+    qsort(keys, n, sizeof(*keys), merge_key_cmp);
+
+    ws->merge_order = (size_t *)malloc(n * sizeof(size_t));
+    if (!ws->merge_order) { free(keys); return; }
+    for (size_t i = 0; i < n; i++) ws->merge_order[i] = keys[i].idx;
+    free(keys);
+}
+
+int lxr_worksheet_in_merge_follow(lxr_worksheet *ws, size_t row, size_t col)
+{
+    size_t i, n;
     if (!ws) return 0;
-    for (i = 0; i < ws->meta.merges_count; i++) {
-        const lxr_range *r = &ws->meta.merges[i];
+    n = ws->meta.merges_count;
+    if (n == 0) return 0;
+
+    if (!ws->merge_index_built) build_merge_index(ws);
+
+    /* Index build failed (OOM): fall back to a plain linear scan. */
+    if (!ws->merge_order) {
+        for (i = 0; i < n; i++) {
+            const lxr_range *r = &ws->meta.merges[i];
+            if (row >= r->first_row && row <= r->last_row &&
+                col >= r->first_col && col <= r->last_col) {
+                return (row == r->first_row && col == r->first_col) ? 0 : 1;
+            }
+        }
+        return 0;
+    }
+
+    /* Reset the cursor when access is not monotonically increasing in row,
+     * so out-of-order callers still get correct results. */
+    if (row < ws->merge_last_row) ws->merge_cursor = 0;
+    ws->merge_last_row = row;
+
+    /* Drop merges that end above this row — they can never match again. */
+    while (ws->merge_cursor < n &&
+           ws->meta.merges[ws->merge_order[ws->merge_cursor]].last_row < row) {
+        ws->merge_cursor++;
+    }
+
+    /* Check the remaining active merges (last_row >= row). */
+    for (i = ws->merge_cursor; i < n; i++) {
+        const lxr_range *r = &ws->meta.merges[ws->merge_order[i]];
         if (row >= r->first_row && row <= r->last_row &&
             col >= r->first_col && col <= r->last_col) {
             /* Inside this range. Master is (first_row, first_col). */

--- a/library/libxlsxreader/src/worksheet_meta.c
+++ b/library/libxlsxreader/src/worksheet_meta.c
@@ -1044,12 +1044,16 @@ void lxr_worksheet_meta_free(lxr_worksheet_meta *m)
 
 size_t lxr_worksheet_merged_count(const lxr_worksheet *ws)
 {
-    return ws ? ws->meta.merges_count : 0;
+    if (!ws) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    return ws->meta.merges_count;
 }
 
 int lxr_worksheet_merged_get(const lxr_worksheet *ws, size_t idx, lxr_range *out)
 {
-    if (!ws || !out || idx >= ws->meta.merges_count) return 0;
+    if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    if (idx >= ws->meta.merges_count) return 0;
     *out = ws->meta.merges[idx];
     return 1;
 }
@@ -1097,6 +1101,7 @@ int lxr_worksheet_in_merge_follow(lxr_worksheet *ws, size_t row, size_t col)
 {
     size_t i, n;
     if (!ws) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
     n = ws->meta.merges_count;
     if (n == 0) return 0;
 
@@ -1139,14 +1144,18 @@ int lxr_worksheet_in_merge_follow(lxr_worksheet *ws, size_t row, size_t col)
 
 size_t lxr_worksheet_hyperlink_count(const lxr_worksheet *ws)
 {
-    return ws ? ws->meta.hyperlinks_count : 0;
+    if (!ws) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    return ws->meta.hyperlinks_count;
 }
 
 int lxr_worksheet_hyperlink_get(const lxr_worksheet *ws, size_t idx,
                                 lxr_hyperlink *out)
 {
     const struct lxr_hyperlink_owned *h;
-    if (!ws || !out || idx >= ws->meta.hyperlinks_count) return 0;
+    if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    if (idx >= ws->meta.hyperlinks_count) return 0;
     h = &ws->meta.hyperlinks[idx];
     out->range    = h->range;
     out->url      = h->url;
@@ -1161,6 +1170,7 @@ const char *lxr_worksheet_hyperlink_url(const lxr_worksheet *ws,
 {
     size_t i;
     if (!ws) return NULL;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return NULL;
     for (i = 0; i < ws->meta.hyperlinks_count; i++) {
         const struct lxr_hyperlink_owned *h = &ws->meta.hyperlinks[i];
         if (row >= h->range.first_row && row <= h->range.last_row &&
@@ -1175,6 +1185,7 @@ int lxr_worksheet_protection(const lxr_worksheet *ws, lxr_protection *out)
 {
     const lxr_worksheet_meta *m;
     if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
     m = &ws->meta;
     out->is_present                = m->prot_present;
     {
@@ -1208,6 +1219,7 @@ int lxr_worksheet_row_options(const lxr_worksheet *ws, size_t row,
 {
     size_t i;
     if (!ws || !out || row == 0) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
     for (i = 0; i < ws->meta.rows_count; i++) {
         const struct lxr_row_meta *r = &ws->meta.rows[i];
         if (r->row == row) {
@@ -1228,6 +1240,7 @@ int lxr_worksheet_col_options(const lxr_worksheet *ws, size_t col,
 {
     size_t i;
     if (!ws || !out || col == 0) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
     for (i = 0; i < ws->meta.cols_count; i++) {
         const struct lxr_col_meta *c = &ws->meta.cols[i];
         if (col >= c->min && col <= c->max) {
@@ -1244,14 +1257,18 @@ int lxr_worksheet_col_options(const lxr_worksheet *ws, size_t col,
 
 int lxr_worksheet_default_row_height(const lxr_worksheet *ws, double *out)
 {
-    if (!ws || !out || !ws->meta.has_default_row_height) return 0;
+    if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    if (!ws->meta.has_default_row_height) return 0;
     *out = ws->meta.default_row_height;
     return 1;
 }
 
 int lxr_worksheet_default_col_width(const lxr_worksheet *ws, double *out)
 {
-    if (!ws || !out || !ws->meta.has_default_col_width) return 0;
+    if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    if (!ws->meta.has_default_col_width) return 0;
     *out = ws->meta.default_col_width;
     return 1;
 }
@@ -1260,14 +1277,18 @@ int lxr_worksheet_default_col_width(const lxr_worksheet *ws, double *out)
 
 size_t lxr_worksheet_data_validation_count(const lxr_worksheet *ws)
 {
-    return ws ? ws->meta.dvs_count : 0;
+    if (!ws) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    return ws->meta.dvs_count;
 }
 
 int lxr_worksheet_data_validation_get(const lxr_worksheet *ws, size_t idx,
                                       lxr_data_validation *out)
 {
     const struct lxr_dv_owned *d;
-    if (!ws || !out || idx >= ws->meta.dvs_count) return 0;
+    if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    if (idx >= ws->meta.dvs_count) return 0;
     d = &ws->meta.dvs[idx];
     out->type               = d->type;
     out->operator_          = d->operator_;
@@ -1290,7 +1311,9 @@ int lxr_worksheet_data_validation_get(const lxr_worksheet *ws, size_t idx,
 
 size_t lxr_worksheet_cf_block_count(const lxr_worksheet *ws)
 {
-    return ws ? ws->meta.cf_blocks_count : 0;
+    if (!ws) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
+    return ws->meta.cf_blocks_count;
 }
 
 int lxr_worksheet_cf_block_get(const lxr_worksheet *ws, size_t idx,
@@ -1300,6 +1323,7 @@ int lxr_worksheet_cf_block_get(const lxr_worksheet *ws, size_t idx,
     const struct lxr_cf_block_owned *bk;
     size_t i;
     if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
     m = (lxr_worksheet_meta *)&ws->meta;
     if (idx >= m->cf_blocks_count) return 0;
     bk = &m->cf_blocks[idx];
@@ -1405,6 +1429,7 @@ int lxr_worksheet_page_setup(const lxr_worksheet *ws, lxr_page_setup *out)
 {
     const lxr_worksheet_meta *m;
     if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
     m = &ws->meta;
     /* If nothing about the page was parsed, surface 0 so callers can return
      * an explicit "no page setup" sentinel. */
@@ -1460,6 +1485,7 @@ int lxr_worksheet_autofilter(const lxr_worksheet *ws, lxr_autofilter *out)
     lxr_worksheet_meta *m;
     size_t i;
     if (!ws || !out) return 0;
+    if (lxr_worksheet_ensure_meta(ws) != LXR_NO_ERROR) return 0;
     m = (lxr_worksheet_meta *)&ws->meta;  /* mutable for cache materialisation */
     if (!m->autofilter_present) return 0;
 

--- a/package.xml
+++ b/package.xml
@@ -239,7 +239,7 @@
    <file md5sum="da217473da36f6b6f6928563171b77ef" name="tests/018.phpt" role="test" />
    <file md5sum="b9494ce1955051dce103015df06f70eb" name="tests/activate_sheet.phpt" role="test" />
    <file md5sum="9afd09472ad777e17ec5197e8efe6e84" name="tests/add_table.phpt" role="test" />
-   <file md5sum="6a8951677ae59b949335c8d4ca9444ad" name="tests/auto_size.phpt" role="test" />
+   <file md5sum="3017c89ac217c5e3385630721a329011" name="tests/auto_size.phpt" role="test" />
    <file md5sum="a68856d4a19b78edd1742ea4bb1f0a49" name="tests/chart_axis_name_x.phpt" role="test" />
    <file md5sum="61ee4f4db478bf31685b0193cd76b21b" name="tests/chart_axis_name_y.phpt" role="test" />
    <file md5sum="75086b73e6e5291bfb15b670d80de3af" name="tests/chart_line.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -49,6 +49,7 @@
 - Feature: insertDynamicFormula() and insertDynamicArrayFormula() emit the t=&quot;array&quot; + ref-range XML that Excel 365 dynamic array functions (UNIQUE, FILTER, SORT, SEQUENCE, XLOOKUP, etc.) require, which insertFormula() does not produce (#503).
 - Feature: outlineSettings(bool $visible = true, bool $below = true, bool $right = true, bool $autoStyle = false) configures worksheet outline (grouping) display (#540).
 - Fix: PHP true/false passed to writeSheet / data now writes a real boolean cell (xlsx type=&quot;b&quot;) via worksheet_write_boolean; previously bool fell through type_writer() silently and the cell was emitted as blank (#543).
+- Feature: autoSize(?string $range = null) sizes columns to fit their content. Column widths are estimated from the written cell values (wide/CJK code points count as two columns) and applied via the existing setColumn machinery. Widths approximate Excel&apos;s own auto-fit, which depends on font metrics only the application knows. Call before output() and before switching sheets (#305).
  </notes>
  <contents>
   <dir name="/">
@@ -238,6 +239,7 @@
    <file md5sum="da217473da36f6b6f6928563171b77ef" name="tests/018.phpt" role="test" />
    <file md5sum="b9494ce1955051dce103015df06f70eb" name="tests/activate_sheet.phpt" role="test" />
    <file md5sum="9afd09472ad777e17ec5197e8efe6e84" name="tests/add_table.phpt" role="test" />
+   <file md5sum="6a8951677ae59b949335c8d4ca9444ad" name="tests/auto_size.phpt" role="test" />
    <file md5sum="a68856d4a19b78edd1742ea4bb1f0a49" name="tests/chart_axis_name_x.phpt" role="test" />
    <file md5sum="61ee4f4db478bf31685b0193cd76b21b" name="tests/chart_axis_name_y.phpt" role="test" />
    <file md5sum="75086b73e6e5291bfb15b670d80de3af" name="tests/chart_line.phpt" role="test" />

--- a/tests/auto_size.phpt
+++ b/tests/auto_size.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Excel::autoSize() sizes columns to content width
+--SKIPIF--
+<?php
+require __DIR__ . '/include/skipif.inc';
+skip_disable_reader();
+?>
+--FILE--
+<?php
+$config = ['path' => './tests'];
+
+$excel = new \Vtiful\Kernel\Excel($config);
+$excel->fileName('auto_size.xlsx', 'S')
+    ->insertText(0, 0, 'hi')                      // A: 2 chars
+    ->insertText(0, 1, 'Hello World')              // B: 11 chars
+    ->insertText(0, 2, '你好世界')                  // C: 4 CJK (display width 8)
+    ->insertText(0, 3, 1234567890)                 // D: 10 digits
+    ->autoSize('A:D')
+    ->output();
+
+$reader = (new \Vtiful\Kernel\Excel($config))
+    ->openFile('auto_size.xlsx')
+    ->openSheet();
+
+/* libxlsxwriter adds Excel's standard column margin (~0.71) on top of the
+ * content width, so the integer part equals the content display width. */
+echo "A (hi):          " . (int) $reader->getColumnOptions('A')['width'] . "\n";
+echo "B (Hello World): " . (int) $reader->getColumnOptions('B')['width'] . "\n";
+echo "C (你好世界):     " . (int) $reader->getColumnOptions('C')['width'] . "\n";
+echo "D (1234567890):  " . (int) $reader->getColumnOptions('D')['width'] . "\n";
+
+/* Without a range argument every column that received data is sized. */
+$excel2 = new \Vtiful\Kernel\Excel($config);
+$excel2->fileName('auto_size2.xlsx', 'S')
+    ->insertText(0, 0, 'short')                            // A: 5
+    ->insertText(0, 5, 'a much longer piece of text here') // F: 32
+    ->autoSize()
+    ->output();
+
+$r2 = (new \Vtiful\Kernel\Excel($config))
+    ->openFile('auto_size2.xlsx')
+    ->openSheet();
+echo "no-range A:      " . (int) $r2->getColumnOptions('A')['width'] . "\n";
+echo "no-range F:      " . (int) $r2->getColumnOptions('F')['width'] . "\n";
+echo "no-range E (no content): ";
+var_dump($r2->getColumnOptions('E'));
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/auto_size.xlsx');
+@unlink(__DIR__ . '/auto_size2.xlsx');
+?>
+--EXPECT--
+A (hi):          2
+B (Hello World): 11
+C (你好世界):     8
+D (1234567890):  10
+no-range A:      5
+no-range F:      32
+no-range E (no content): NULL

--- a/tests/auto_size.phpt
+++ b/tests/auto_size.phpt
@@ -9,13 +9,14 @@ skip_disable_reader();
 <?php
 $config = ['path' => './tests'];
 
+/* autoSize() must be called before the writes it should track. */
 $excel = new \Vtiful\Kernel\Excel($config);
 $excel->fileName('auto_size.xlsx', 'S')
+    ->autoSize('A:D')
     ->insertText(0, 0, 'hi')                      // A: 2 chars
     ->insertText(0, 1, 'Hello World')              // B: 11 chars
     ->insertText(0, 2, '你好世界')                  // C: 4 CJK (display width 8)
     ->insertText(0, 3, 1234567890)                 // D: 10 digits
-    ->autoSize('A:D')
     ->output();
 
 $reader = (new \Vtiful\Kernel\Excel($config))
@@ -29,12 +30,22 @@ echo "B (Hello World): " . (int) $reader->getColumnOptions('B')['width'] . "\n";
 echo "C (你好世界):     " . (int) $reader->getColumnOptions('C')['width'] . "\n";
 echo "D (1234567890):  " . (int) $reader->getColumnOptions('D')['width'] . "\n";
 
+/* A 5000-char cell is clamped to Excel's 255 max width. */
+$big = str_repeat('x', 5000);
+$excel3 = new \Vtiful\Kernel\Excel($config);
+$excel3->fileName('auto_size3.xlsx', 'S')
+    ->autoSize('A:A')
+    ->insertText(0, 0, $big)
+    ->output();
+$r3 = (new \Vtiful\Kernel\Excel($config))->openFile('auto_size3.xlsx')->openSheet();
+echo "clamp:           " . (int) $r3->getColumnOptions('A')['width'] . "\n";
+
 /* Without a range argument every column that received data is sized. */
 $excel2 = new \Vtiful\Kernel\Excel($config);
 $excel2->fileName('auto_size2.xlsx', 'S')
+    ->autoSize()
     ->insertText(0, 0, 'short')                            // A: 5
     ->insertText(0, 5, 'a much longer piece of text here') // F: 32
-    ->autoSize()
     ->output();
 
 $r2 = (new \Vtiful\Kernel\Excel($config))
@@ -42,19 +53,29 @@ $r2 = (new \Vtiful\Kernel\Excel($config))
     ->openSheet();
 echo "no-range A:      " . (int) $r2->getColumnOptions('A')['width'] . "\n";
 echo "no-range F:      " . (int) $r2->getColumnOptions('F')['width'] . "\n";
-echo "no-range E (no content): ";
-var_dump($r2->getColumnOptions('E'));
+
+/* Without autoSize() the writes are not tracked at all. */
+$excel4 = new \Vtiful\Kernel\Excel($config);
+$excel4->fileName('auto_size4.xlsx', 'S')
+    ->insertText(0, 0, 'not tracked')
+    ->output();
+$r4 = (new \Vtiful\Kernel\Excel($config))->openFile('auto_size4.xlsx')->openSheet();
+echo "no-autoSize A:   ";
+var_dump($r4->getColumnOptions('A'));
 ?>
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/auto_size.xlsx');
 @unlink(__DIR__ . '/auto_size2.xlsx');
+@unlink(__DIR__ . '/auto_size3.xlsx');
+@unlink(__DIR__ . '/auto_size4.xlsx');
 ?>
 --EXPECT--
 A (hi):          2
 B (Hello World): 11
 C (你好世界):     8
 D (1234567890):  10
+clamp:           255
 no-range A:      5
 no-range F:      32
-no-range E (no content): NULL
+no-autoSize A:   NULL


### PR DESCRIPTION
## Summary

Reader-side memory-safety hardening plus two performance optimizations targeting large-sheet reads. No changes to PHP method signatures, return types, or constant values.

## Memory safety (`792f053`)

- **RichString zend_string leak**: `RichString::__construct` copied the text via `zend_string_copy` but the object destructor never released it — every `Vtiful\Kernel\RichString` leaked one `zend_string`. The copy is now owned by the object and released in the dtor.
- **RichString object offset**: `php_vtiful_rich_string_fetch_object` used `XtOffsetOf(validation_object, zo)` instead of `rich_string_object`; worked only by accidental struct-layout coincidence.
- **Callback return-value safety**: the cell/row-end/image/comment/chart callback bridges declared `zval retval;` uninitialized, called `zend_call_function`, then unconditionally `zval_ptr_dtor`'d the result. If the callback threw or failed, this destructured an uninitialized zval. All bridges now `ZVAL_UNDEF`, check the call result, and only dtor when initialized.
- **CSV error path**: `xlsx_to_csv` leaked `_zv_tmp_row` on the write-failure return.
- **Reader state reset**: `openFile()` didn't clear `pending_real_row` / synth-row bookkeeping the way `openSheet()` and the object dtor did. Extracted `php_vtiful_reset_reader_state()` and used it everywhere.
- **workbook/worksheet alloc failures**: `fileName()` / `constMemory()` now check `workbook_new*` / `workbook_add_worksheet` results; on failure they free the half-built workbook and throw.

## Performance

**Lazy worksheet metadata (`71802ab`)** — the reader used to do a full second XML scan of every sheet at `openSheet()` time to collect merges/hyperlinks/protection/row-col options. Data-only reads (`getSheetData`, `nextRow`, `nextCellCallback`, `putCSV`) never need that metadata, so it's now loaded on first metadata-accessor call instead. `nextRowWithFormula` (which surfaces per-cell hyperlink URLs) and `SKIP_MERGED_FOLLOW` reads pre-load it before streaming, so behaviour is unchanged.

**Merge-follow index (`aa2d9b2`)** — `lxr_worksheet_in_merge_follow` previously did a linear scan over all merge ranges for every cell. With many merged cells this degraded to O(cells × merges). Merges are now re-indexed by `last_row` (lazily, on first query) and a cursor skips ranges that end above the current row, giving amortised near-O(1) for sequential row scans.

## Benchmarks

Same machine, PHP 8.2, identical fixtures, median of 7 runs:

| Workload | Size | before | after | change |
|---|---|---|---|---|
| `getSheetData` | 100k×10 | 0.595s | 0.344s | −42% |
| `nextRow` | 100k×10 | 0.600s | 0.347s | −42% |
| `SKIP_MERGED_FOLLOW` read (~10k merges) | 30k×10 | 1.222s | 0.671s | −45% |
| `nextRowWithFormula` | 100k×10 | 0.648s | 0.658s | ~same (needs metadata) |
| `write` (output) | 100k×10 | 0.741s | 0.744s | ~same |

## Verification

- `make test`: 164/164 pass
- `USE_ZEND_ALLOC=0 make test`: 164/164 pass
- libxlsxreader `ctest`: 10/10 pass
- PHP leak check (`USE_ZEND_ALLOC=0 MallocStackLogging=1 leaks`): 0 leaks
- C leak checks (`test_smoke`, `test_phase1_meta`, `test_worksheet`): 0 leaks
