### PR TITLE
chore(deps): upgrade libxlsxwriter to 1.2.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "library/libxlsxwriter"]
 	path = library/libxlsxwriter
 	url = https://github.com/jmcnamara/libxlsxwriter.git
-	branch = RELEASE_1.1.6
+	branch = v1.2.4
 [submodule "library/libexpat"]
 	path = library/libexpat
 	url = https://github.com/libexpat/libexpat.git

--- a/config.m4
+++ b/config.m4
@@ -82,6 +82,10 @@ if test "$PHP_XLSWRITER" != "no"; then
     library/libxlsxwriter/src/workbook.c \
     library/libxlsxwriter/src/worksheet.c \
     library/libxlsxwriter/src/xmlwriter.c \
+    library/libxlsxwriter/src/rich_value.c \
+    library/libxlsxwriter/src/rich_value_rel.c \
+    library/libxlsxwriter/src/rich_value_structure.c \
+    library/libxlsxwriter/src/rich_value_types.c \
     "
 
     libexpat="

--- a/config.w32
+++ b/config.w32
@@ -73,6 +73,10 @@ if (PHP_XLSWRITER != "no") {
                 workbook.c \
                 worksheet.c \
                 xmlwriter.c \
+                rich_value.c \
+                rich_value_rel.c \
+                rich_value_structure.c \
+                rich_value_types.c \
                 ", "xlswriter", "libxlsxwriter");
 
         ADD_SOURCES(configure_module_dirname + "\\library\\libexpat\\expat\\lib", "\

--- a/kernel/write.c
+++ b/kernel/write.c
@@ -865,8 +865,15 @@ workbook_file(xls_resource_write_t *self)
         if (worksheet->index == self->workbook->active_sheet)
             worksheet->active = 1;
 
-        if (worksheet->has_dynamic_arrays)
+        if (worksheet->has_dynamic_functions) {
             self->workbook->has_metadata = LXW_TRUE;
+            self->workbook->has_dynamic_functions = 1;
+        }
+
+        if (!STAILQ_EMPTY(worksheet->embedded_image_props)) {
+            self->workbook->has_metadata = LXW_TRUE;
+            self->workbook->has_embedded_images = 1;
+        }
     }
 
     /* Set workbook and worksheet VBA codenames if a macro has been added. */

--- a/package.xml
+++ b/package.xml
@@ -108,6 +108,10 @@
    <file md5sum="6f0aeb1bf8f856cd3e5e373c9e24c0ff" name="library/libxlsxwriter/include/xlsxwriter/metadata.h" role="src" />
    <file md5sum="6e045122fb3e6529fd4cafb94316893b" name="library/libxlsxwriter/include/xlsxwriter/packager.h" role="src" />
    <file md5sum="b116a318e30cf8a486b81e8ab2f2fff9" name="library/libxlsxwriter/include/xlsxwriter/relationships.h" role="src" />
+   <file md5sum="e450c414bf40de71fea8c944bdfffc60" name="library/libxlsxwriter/include/xlsxwriter/rich_value.h" role="src" />
+   <file md5sum="16c1bb096b62e0a019fb42e7b8e1815f" name="library/libxlsxwriter/include/xlsxwriter/rich_value_rel.h" role="src" />
+   <file md5sum="77ef0be5bf546e1cc6a952237846c05a" name="library/libxlsxwriter/include/xlsxwriter/rich_value_structure.h" role="src" />
+   <file md5sum="5dc01a81c8427e8c93f0c2fb3494a736" name="library/libxlsxwriter/include/xlsxwriter/rich_value_types.h" role="src" />
    <file md5sum="e94d78abe914dbe732a13ea6672ad5c0" name="library/libxlsxwriter/include/xlsxwriter/shared_strings.h" role="src" />
    <file md5sum="fa8a02d461c250c655aa4c0cf39e92bd" name="library/libxlsxwriter/include/xlsxwriter/styles.h" role="src" />
    <file md5sum="90bd82018324493fe4ca5d2f6d123931" name="library/libxlsxwriter/include/xlsxwriter/table.h" role="src" />
@@ -148,6 +152,10 @@
    <file md5sum="719de339151177e6b16e292e77b1baff" name="library/libxlsxwriter/src/metadata.c" role="src" />
    <file md5sum="2f954a12bb9b6a9cf05004cc27ce7c01" name="library/libxlsxwriter/src/packager.c" role="src" />
    <file md5sum="1890e18cbffc1dd1debf143b192201d0" name="library/libxlsxwriter/src/relationships.c" role="src" />
+   <file md5sum="bc0012d97aa9e4ec373369ec1672a3b0" name="library/libxlsxwriter/src/rich_value.c" role="src" />
+   <file md5sum="26e123cff0699d480d50fca7063d1d72" name="library/libxlsxwriter/src/rich_value_rel.c" role="src" />
+   <file md5sum="7191ad4dd706ad8ed1b6f30aef666b45" name="library/libxlsxwriter/src/rich_value_structure.c" role="src" />
+   <file md5sum="439135117eae7d8d379e8f64f27e0321" name="library/libxlsxwriter/src/rich_value_types.c" role="src" />
    <file md5sum="7f54d7d1344eede97c07bec7ca11eeb4" name="library/libxlsxwriter/src/shared_strings.c" role="src" />
    <file md5sum="f1b0c3e9abefa3399c31c25ab82aa00e" name="library/libxlsxwriter/src/styles.c" role="src" />
    <file md5sum="185f6fce2cf96c9f3d22291306cfab4b" name="library/libxlsxwriter/src/table.c" role="src" />

--- a/tests/writer_exception.phpt
+++ b/tests/writer_exception.phpt
@@ -22,5 +22,5 @@ Check for vtiful presence
 @unlink(__DIR__ . '/writer_exception.xlsx');
 ?>
 --EXPECT--
-23
+25
 Worksheet row or column index out of range.


### PR DESCRIPTION
Sync the vendored workbook_file() close-prep loop with upstream's workbook_close(): has_dynamic_arrays was renamed to has_dynamic_functions in 1.2.x, and the loop now also sets the workbook-level dynamic-functions/embedded-images flags.

Update writer_exception.phpt: LXW_ERROR_WORKSHEET_INDEX_OUT_OF_RANGE shifted 23 -> 25 after 1.2.4 inserted two new lxw_error enum values (LXW_ERROR_PARAMETER_IS_EMPTY, LXW_ERROR_DATETIME_VALIDATION). Semantics and message unchanged.

All 165 PHPT pass on 1.2.4.