### PR TITLE
fix: high-severity review defects and locale-independent number handling

### DIFF
--- a/kernel/read.c
+++ b/kernel/read.c
@@ -384,15 +384,18 @@ static int lxlsx_reader_cell_bridge(const lxlsx_cell *c, void *callback_data)
 
     if (Z_TYPE_P(_cd->zv_type_t) != IS_ARRAY && _cd->data_type_default == READ_TYPE_EMPTY) {
         zend_long _long = 0; double _double = 0;
-        if (is_numeric_string(str, str_len, &_long, &_double, 0)) {
-            /* Both branches expand to macros that PHP 7.4 defines as bare
-             * `{ ... }` blocks; without explicit braces the trailing `;`
-             * orphans the else. Same shape as the fix in kernel/excel.c. */
-            if (_double > 0) {
-                ZVAL_DOUBLE(&args[2], _double);
-            } else {
-                ZVAL_LONG(&args[2], _long);
-            }
+        int kind = is_numeric_string(str, str_len, &_long, &_double, 0);
+        /* Dispatch on the kind reported by is_numeric_string, not on the
+         * sign of _double: a negative or zero double (e.g. "-5.5") sets
+         * _double only and leaves _long at 0, so a `_double > 0` test would
+         * emit ZVAL_LONG(0) and corrupt the value. Same shape as the fix in
+         * kernel/excel.c. Braces are mandatory: on PHP 7.4 some Z_VAL_*
+         * macros expand to a bare `{ ... }` block, so chaining
+         * `if (...) MACRO; else if (...) MACRO;` orphans the else. */
+        if (kind == IS_LONG) {
+            ZVAL_LONG(&args[2], _long);
+        } else if (kind == IS_DOUBLE) {
+            ZVAL_DOUBLE(&args[2], _double);
         } else {
             ZVAL_STRINGL(&args[2], str, str_len);
         }

--- a/library/libxlsx/include/libxlsx/utility.h
+++ b/library/libxlsx/include/libxlsx/utility.h
@@ -312,6 +312,11 @@ int lxlsx_sprintf_dbl(char *data, double number);
         lxlsx_snprintf(data, LXLSX_ATTR_32, "%.16G", number)
 #endif
 
+/* Locale-independent strtod: OOXML decimals always use '.', regardless of the
+ * host LC_NUMERIC. Use this instead of strtod() when parsing values read from
+ * the xlsx XML. */
+double lxlsx_strtod(const char *str, char **endptr);
+
 uint16_t lxlsx_hash_password(const char *password);
 
 /* *INDENT-OFF* */

--- a/library/libxlsx/include/libxlsx/xmlwriter.h
+++ b/library/libxlsx/include/libxlsx/xmlwriter.h
@@ -78,21 +78,24 @@ struct lxlsx_xml_attribute *lxlsx_new_attribute_dbl(const char *key, double valu
 #define LXLSX_PUSH_ATTRIBUTES_STR(key, value)                   \
     do {                                                      \
     attribute = lxlsx_new_attribute_str((key), (value));        \
-    STAILQ_INSERT_TAIL(&attributes, attribute, list_entries); \
+    if (attribute)                                            \
+        STAILQ_INSERT_TAIL(&attributes, attribute, list_entries); \
     } while (0)
 
 /* Macro to add attribute int values to lxlsx_xml_attribute_list. */
 #define LXLSX_PUSH_ATTRIBUTES_INT(key, value)                   \
     do {                                                      \
     attribute = lxlsx_new_attribute_int((key), (value));        \
-    STAILQ_INSERT_TAIL(&attributes, attribute, list_entries); \
+    if (attribute)                                            \
+        STAILQ_INSERT_TAIL(&attributes, attribute, list_entries); \
     } while (0)
 
 /* Macro to add attribute double values to lxlsx_xml_attribute_list. */
 #define LXLSX_PUSH_ATTRIBUTES_DBL(key, value)                   \
     do {                                                      \
     attribute = lxlsx_new_attribute_dbl((key), (value));        \
-    STAILQ_INSERT_TAIL(&attributes, attribute, list_entries); \
+    if (attribute)                                            \
+        STAILQ_INSERT_TAIL(&attributes, attribute, list_entries); \
     } while (0)
 
 /* Macro to free lxlsx_xml_attribute_list and attribute. */

--- a/library/libxlsx/src/chart.c
+++ b/library/libxlsx/src/chart.c
@@ -7487,8 +7487,11 @@ lxlsx_reader_error lxlsx_reader_worksheet_iterate_charts(lxlsx_reader_worksheet 
                         }
                     }
                 }
-                info.series       = info_series;
-                info.series_count = ch.series_count;
+                info.series = info_series;
+                /* Keep count consistent with the pointer: on calloc failure
+                 * info_series is NULL, so report zero series rather than let
+                 * the callback walk a NULL array by the original count. */
+                info.series_count = info_series ? ch.series_count : 0;
 
                 if (cb(&info, userdata) != 0) stop = 1;
                 free(info_series);

--- a/library/libxlsx/src/edit.c
+++ b/library/libxlsx/src/edit.c
@@ -654,7 +654,7 @@ static int looks_numeric(const char *str)
     char *end = NULL;
     if (!str || !*str)
         return 0;
-    (void)strtod(str, &end);
+    (void)lxlsx_strtod(str, &end);
     return end && *end == 0;
 }
 
@@ -697,7 +697,7 @@ static lxlsx_error append_cell_xml(lxlsx_edit_buf *buf,
         return LXLSX_ERROR_MEMORY_MALLOC_FAILED;
 
     if (change->type == LXLSX_EDIT_CHANGE_NUMBER) {
-        snprintf(number, sizeof(number), "%.17g", change->number);
+        lxlsx_sprintf_dbl(number, change->number);  /* locale-independent */
         if (buf_append_s(buf, "<v>") != 0 ||
             buf_append_s(buf, number) != 0 ||
             buf_append_s(buf, "</v>") != 0)
@@ -2276,7 +2276,11 @@ static lxlsx_error patch_xml_with_row_dims(unsigned char **xml, size_t *xml_len,
             if (buf_append(&out, ap, 1) != 0) { err = LXLSX_ERROR_MEMORY_MALLOC_FAILED; goto done; }
             ap++;
         }
-        snprintf(attr, sizeof(attr), " ht=\"%g\" customHeight=\"1\"", height);
+        {
+            char htbuf[LXLSX_ATTR_32];
+            lxlsx_sprintf_dbl(htbuf, height);  /* locale-independent */
+            snprintf(attr, sizeof(attr), " ht=\"%s\" customHeight=\"1\"", htbuf);
+        }
         if (buf_append_s(&out, attr) != 0 ||
             buf_append_s(&out, self_closing ? "/>" : ">") != 0) { err = LXLSX_ERROR_MEMORY_MALLOC_FAILED; goto done; }
         p = gt + 1;
@@ -2454,7 +2458,11 @@ static int emit_font_fragment(lxlsx_edit_buf *b, const lxlsx_format *f)
         if (buf_append_s(b, f->underline == 2 ? "<u val=\"double\"/>" : "<u/>") != 0)
             return -1;
     }
-    snprintf(tmp, sizeof(tmp), "<sz val=\"%g\"/>", f->font_size > 0 ? f->font_size : 11.0);
+    {
+        char szbuf[LXLSX_ATTR_32];
+        lxlsx_sprintf_dbl(szbuf, f->font_size > 0 ? f->font_size : 11.0);
+        snprintf(tmp, sizeof(tmp), "<sz val=\"%s\"/>", szbuf);
+    }
     if (buf_append_s(b, tmp) != 0) return -1;
     if (f->font_color != LXLSX_COLOR_UNSET) {
         snprintf(tmp, sizeof(tmp), "<color rgb=\"FF%06X\"/>",

--- a/library/libxlsx/src/formula.c
+++ b/library/libxlsx/src/formula.c
@@ -15,6 +15,22 @@
 #include "libxlsx/formula.h"
 #include "libxlsx/utility.h"
 
+/* Guards against pathological input from untrusted formulas. The formula
+ * string, the recursive-descent parser and the range evaluator all take
+ * attacker-controlled input (see lxlsx_formula_eval), so each is bounded:
+ *   - MAX_LEN caps the source length, which in turn bounds the AST size and
+ *     therefore the eval()/node_free() recursion on a flat left-leaning tree
+ *     such as 1+1+1+...;
+ *   - MAX_DEPTH caps recursive-descent nesting (deeply nested parens / unary
+ *     '-' / function args), which would otherwise blow the C stack;
+ *   - MAX_RANGE_CELLS caps how many cells one range aggregate visits so a
+ *     single =SUM(A1:XFD1048576) can't spin for hours.
+ * Excel's own limits (8192-char formulas, 64 nesting levels) sit well under
+ * these, so real formulas are unaffected. */
+#define LXLSX_FORMULA_MAX_LEN         8192
+#define LXLSX_FORMULA_MAX_DEPTH       256
+#define LXLSX_FORMULA_MAX_RANGE_CELLS 1048576u
+
 /* ===================================================================== *
  * Value helpers
  * ===================================================================== */
@@ -103,6 +119,7 @@ typedef struct {
     size_t pos, n;
     tok cur;
     int failed;     /* parse error */
+    int depth;      /* recursive-descent nesting, bounded by MAX_DEPTH */
 } pstate;
 
 static int is_idstart(char c) {
@@ -170,7 +187,7 @@ static void lex_next(pstate *p)
 
     if ((c >= '0' && c <= '9') || c == '.') {   /* number */
         char *end = NULL;
-        p->cur.num = strtod(p->src + p->pos, &end);
+        p->cur.num = lxlsx_strtod(p->src + p->pos, &end);
         p->cur.kind = TK_NUMBER;
         p->pos = (size_t)(end - p->src);
         return;
@@ -404,8 +421,12 @@ static node *parse_postfix(pstate *p)
 static node *parse_unary(pstate *p)
 {
     if (op_is(p, "-") || op_is(p, "+")) {
-        char op[3]; strcpy(op, p->cur.op); lex_next(p);
-        return make_unary(p, op, parse_unary(p));
+        char op[3]; node *operand;
+        strcpy(op, p->cur.op); lex_next(p);
+        if (++p->depth > LXLSX_FORMULA_MAX_DEPTH) { p->depth--; p->failed = 1; return NULL; }
+        operand = parse_unary(p);
+        p->depth--;
+        return make_unary(p, op, operand);
     }
     return parse_postfix(p);
 }
@@ -441,12 +462,15 @@ static node *parse_concat(pstate *p)
 }
 static node *parse_expr(pstate *p)
 {
-    node *a = parse_concat(p);
+    node *a;
+    if (++p->depth > LXLSX_FORMULA_MAX_DEPTH) { p->depth--; p->failed = 1; return NULL; }
+    a = parse_concat(p);
     while (op_is(p, "=") || op_is(p, "<>") || op_is(p, "<") ||
            op_is(p, ">") || op_is(p, "<=") || op_is(p, ">=")) {
         char op[3]; strcpy(op, p->cur.op); lex_next(p);
         a = make_binary(p, op, a, parse_concat(p));
     }
+    p->depth--;
     return a;
 }
 
@@ -473,7 +497,7 @@ static double to_number(const lxlsx_value *v, lxlsx_formula_error *err)
     case LXLSX_VAL_STRING: {
         if (!v->string || !*v->string) return 0.0;
         char *end = NULL;
-        double d = strtod(v->string, &end);
+        double d = lxlsx_strtod(v->string, &end);
         while (end && (*end == ' ' || *end == '\t')) end++;
         if (end && *end == '\0') return d;
         *err = LXLSX_FERR_VALUE; return 0.0;
@@ -501,7 +525,7 @@ static char *to_string(const lxlsx_value *v)
         if (d == (double)(long long)d && fabs(d) < 1e15)
             snprintf(buf, sizeof(buf), "%lld", (long long)d);
         else
-            snprintf(buf, sizeof(buf), "%.15g", d);
+            lxlsx_sprintf_dbl(buf, d);  /* locale-independent decimal point */
         return strdup(buf);
     }
     }
@@ -528,6 +552,19 @@ static void iterate_range(ev *e, node *n, range_cb cb, void *acc)
     lxlsx_col_t c1 = n->col, c2 = n->col2;
     if (r1 > r2) { lxlsx_row_t t = r1; r1 = r2; r2 = t; }
     if (c1 > c2) { lxlsx_col_t t = c1; c1 = c2; c2 = t; }
+    /* Refuse ranges that would visit an absurd number of cells (e.g.
+     * A1:XFD1048576). Surface a #NUM! error through the accumulator rather
+     * than brute-forcing billions of resolver calls. */
+    {
+        uint64_t rows  = (uint64_t)(r2 - r1) + 1;
+        uint64_t cols  = (uint64_t)(c2 - c1) + 1;
+        if (rows * cols > LXLSX_FORMULA_MAX_RANGE_CELLS) {
+            lxlsx_value err = val_error(LXLSX_FERR_NUM);
+            cb(acc, &err);
+            lxlsx_value_free(&err);
+            return;
+        }
+    }
     for (r = r1; r <= r2; r++) {
         for (c = c1; c <= c2; c++) {
             lxlsx_value v = resolve_cell(e, r, c);
@@ -885,6 +922,16 @@ lxlsx_error lxlsx_formula_eval(const char *formula,
     p.pos = 0;
     p.n = strlen(formula);
     p.failed = 0;
+    p.depth = 0;
+
+    /* Reject pathologically long input up front: it bounds AST size and thus
+     * the eval()/node_free() recursion depth. Surface as an in-band error,
+     * matching the unparseable-formula path below. */
+    if (p.n > LXLSX_FORMULA_MAX_LEN) {
+        *out = val_error(LXLSX_FERR_NAME);
+        return LXLSX_NO_ERROR;
+    }
+
     lex_next(&p);
 
     root = parse_expr(&p);

--- a/library/libxlsx/src/sst.c
+++ b/library/libxlsx/src/sst.c
@@ -4,6 +4,7 @@
 #include "sst.h"
 #include "xlsx_util.h"
 #include "xml_pump.h"
+#include "libxlsx/utility.h"
 
 /* Per-SI run accumulator — populated while scanning <r>...</r>. */
 typedef struct {
@@ -222,7 +223,7 @@ static void on_start(void *ud, const char *name, const char **attrs)
                     }
                 }
             } else if (lxlsx_reader_xml_name_eq(name, "sz")) {
-                if ((v = lxlsx_reader_xml_attr(attrs, "val"))) s->pending.font_size = strtod(v, NULL);
+                if ((v = lxlsx_reader_xml_attr(attrs, "val"))) s->pending.font_size = lxlsx_strtod(v, NULL);
             } else if (lxlsx_reader_xml_name_eq(name, "b")) {
                 v = lxlsx_reader_xml_attr(attrs, "val");
                 s->pending.bold = !v || strcmp(v, "0") != 0;

--- a/library/libxlsx/src/styles.c
+++ b/library/libxlsx/src/styles.c
@@ -2001,7 +2001,7 @@ static void extract_color(const lxlsx_reader_styles *st,
 
     tint = lxlsx_reader_xml_attr(attrs, "tint");
     if (have_color && tint) {
-        apply_tint(out, strtod(tint, NULL));
+        apply_tint(out, lxlsx_strtod(tint, NULL));
     }
 }
 
@@ -2132,7 +2132,7 @@ static void parse_font_child(const lxlsx_reader_styles *st,
     if (!f) return;
     if (lxlsx_reader_xml_name_eq(name, "sz")) {
         const char *v = lxlsx_reader_xml_attr(attrs, "val");
-        if (v) f->size = strtod(v, NULL);
+        if (v) f->size = lxlsx_strtod(v, NULL);
     } else if (lxlsx_reader_xml_name_eq(name, "name") || lxlsx_reader_xml_name_eq(name, "rFont")) {
         const char *v = lxlsx_reader_xml_attr(attrs, "val");
         if (v) { free((void *)f->name); f->name = strdup(v); }

--- a/library/libxlsx/src/utility.c
+++ b/library/libxlsx/src/utility.c
@@ -13,6 +13,7 @@
 #endif
 
 #include <ctype.h>
+#include <locale.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -758,6 +759,56 @@ lxlsx_sprintf_dbl(char *data, double number)
     return 0;
 }
 #endif
+
+/*
+ * Locale-independent strtod. OOXML always stores decimals with '.', but
+ * strtod() honours LC_NUMERIC, so if the host (e.g. a PHP script that called
+ * setlocale(LC_ALL, "de_DE")) selected a ',' decimal separator, a plain
+ * strtod("3.14") would stop at the '.' and read 3. This mirrors the writer's
+ * use of lxlsx_sprintf_dbl for locale-portable output. The fast path (C/POSIX
+ * locale, the common case) is a straight strtod; only a non-'.' locale pays
+ * for a translated scratch copy.
+ */
+double
+lxlsx_strtod(const char *str, char **endptr)
+{
+    struct lconv *lc = localeconv();
+    char sep = (lc && lc->decimal_point) ? lc->decimal_point[0] : '.';
+
+    /* Fast path: the locale already uses a single-byte '.' separator. */
+    if (sep == '.' && lc->decimal_point[1] == '\0')
+        return strtod(str, endptr);
+
+    /* Only a single-byte separator can be translated 1:1 while keeping byte
+     * offsets (needed to map endptr back). No real locale uses a multi-byte
+     * decimal point; fall back to plain strtod in that theoretical case. */
+    if (lc->decimal_point[1] != '\0')
+        return strtod(str, endptr);
+
+    {
+        size_t len = strlen(str);
+        char   stackbuf[128];
+        char  *copy = (len < sizeof(stackbuf)) ? stackbuf : malloc(len + 1);
+        char  *end  = NULL;
+        double value;
+        size_t i;
+
+        if (!copy)                       /* OOM: best-effort fallback */
+            return strtod(str, endptr);
+
+        for (i = 0; i <= len; i++)
+            copy[i] = (str[i] == '.') ? sep : str[i];
+
+        value = strtod(copy, &end);
+        if (endptr)
+            *endptr = (char *) str + (end - copy);
+
+        if (copy != stackbuf)
+            free(copy);
+
+        return value;
+    }
+}
 
 /*
  * Retrieve runtime library version.

--- a/library/libxlsx/src/worksheet.c
+++ b/library/libxlsx/src/worksheet.c
@@ -8437,7 +8437,7 @@ lxlsx_worksheet_write_formula_num(lxlsx_worksheet *self,
         if (err)
             return err;
 
-        snprintf(result_buf, sizeof(result_buf), "%.15g", result);
+        lxlsx_sprintf_dbl(result_buf, result);  /* locale-independent */
         err = lxlsx_edit_set_formula(self->edit_session, self->edit_sheet_name,
                                      row_num, col_num, formula, result_buf);
         if (err)
@@ -12491,7 +12491,7 @@ static void emit_cell(lxlsx_reader_worksheet *ws, lxlsx_cell *out)
         if (xf && (xf->category == LXLSX_READER_FMT_CATEGORY_DATE ||
                    xf->category == LXLSX_READER_FMT_CATEGORY_TIME ||
                    xf->category == LXLSX_READER_FMT_CATEGORY_DATETIME)) {
-            double serial = ws->cell_value ? strtod(ws->cell_value, NULL) : 0.0;
+            double serial = ws->cell_value ? lxlsx_strtod(ws->cell_value, NULL) : 0.0;
             out->type = DATETIME_CELL;
             out->data.reader.value.unix_timestamp =
                 lxlsx_reader_excel_serial_to_unix(serial,
@@ -12499,7 +12499,7 @@ static void emit_cell(lxlsx_reader_worksheet *ws, lxlsx_cell *out)
         } else {
             out->type = NUMBER_CELL;
             out->data.reader.value.number =
-                ws->cell_value ? strtod(ws->cell_value, NULL) : 0.0;
+                ws->cell_value ? lxlsx_strtod(ws->cell_value, NULL) : 0.0;
         }
         return;
     }
@@ -12858,7 +12858,7 @@ static void on_start(void *ud, const char *name, const char **attrs)
                     }
                 }
             } else if (lxlsx_reader_xml_name_eq(name, "sz")) {
-                if ((v = lxlsx_reader_xml_attr(attrs, "val"))) ws->inline_pending_font_size = strtod(v, NULL);
+                if ((v = lxlsx_reader_xml_attr(attrs, "val"))) ws->inline_pending_font_size = lxlsx_strtod(v, NULL);
             } else if (lxlsx_reader_xml_name_eq(name, "b")) {
                 v = lxlsx_reader_xml_attr(attrs, "val");
                 ws->inline_pending_bold = !v || strcmp(v, "0") != 0;
@@ -13564,11 +13564,11 @@ static void m_on_start(void *ud, const char *name, const char **attrs)
             const char *dcw = lxlsx_reader_xml_attr(attrs, "defaultColWidth");
             if (drh) {
                 c->m->has_default_row_height = 1;
-                c->m->default_row_height = strtod(drh, NULL);
+                c->m->default_row_height = lxlsx_strtod(drh, NULL);
             }
             if (dcw) {
                 c->m->has_default_col_width = 1;
-                c->m->default_col_width = strtod(dcw, NULL);
+                c->m->default_col_width = lxlsx_strtod(dcw, NULL);
             }
             /* element is empty / self-closing in practice — stay in WORKSHEET */
         } else if (lxlsx_reader_xml_name_eq(name, "cols")) {
@@ -13595,12 +13595,12 @@ static void m_on_start(void *ud, const char *name, const char **attrs)
             const char *h = lxlsx_reader_xml_attr(attrs, "header");
             const char *f = lxlsx_reader_xml_attr(attrs, "footer");
             c->m->page_has_margins = 1;
-            if (l) c->m->page_margin_left   = strtod(l, NULL);
-            if (r) c->m->page_margin_right  = strtod(r, NULL);
-            if (t) c->m->page_margin_top    = strtod(t, NULL);
-            if (b) c->m->page_margin_bottom = strtod(b, NULL);
-            if (h) c->m->page_margin_header = strtod(h, NULL);
-            if (f) c->m->page_margin_footer = strtod(f, NULL);
+            if (l) c->m->page_margin_left   = lxlsx_strtod(l, NULL);
+            if (r) c->m->page_margin_right  = lxlsx_strtod(r, NULL);
+            if (t) c->m->page_margin_top    = lxlsx_strtod(t, NULL);
+            if (b) c->m->page_margin_bottom = lxlsx_strtod(b, NULL);
+            if (h) c->m->page_margin_header = lxlsx_strtod(h, NULL);
+            if (f) c->m->page_margin_footer = lxlsx_strtod(f, NULL);
         } else if (lxlsx_reader_xml_name_eq(name, "pageSetup")) {
             const char *v;
             c->m->page_has_setup = 1;
@@ -13683,7 +13683,7 @@ static void m_on_start(void *ud, const char *name, const char **attrs)
                 col->min = vmin ? (size_t)strtoul(vmin, NULL, 10) : 0;
                 col->max = vmax ? (size_t)strtoul(vmax, NULL, 10) : col->min;
                 if (vw) {
-                    col->width = strtod(vw, NULL);
+                    col->width = lxlsx_strtod(vw, NULL);
                     /* OOXML lists customWidth=1 when an explicit width was set;
                      * absent customWidth on a width attr is the default-derived
                      * value the writer emits. Treat any present width as
@@ -13776,7 +13776,7 @@ static void m_on_start(void *ud, const char *name, const char **attrs)
                 fc->kind      = LXLSX_READER_FILTER_TOP10;
                 fc->top       = top_attr ? attr_truthy(top_attr) : 1;
                 fc->percent   = attr_truthy(pct_attr);
-                fc->top_value = val_attr ? strtod(val_attr, NULL) : 0;
+                fc->top_value = val_attr ? lxlsx_strtod(val_attr, NULL) : 0;
                 enter_skip(c, name);
             } else if (lxlsx_reader_xml_name_eq(name, "dynamicFilter")) {
                 fc->kind = LXLSX_READER_FILTER_DYNAMIC;
@@ -13804,7 +13804,7 @@ static void m_on_start(void *ud, const char *name, const char **attrs)
                 if ((v = lxlsx_reader_xml_attr(attrs, "operator")))    r->operator_   = strdup(v);
                 if ((v = lxlsx_reader_xml_attr(attrs, "priority")))    r->priority    = (int)strtol(v, NULL, 10);
                 if ((v = lxlsx_reader_xml_attr(attrs, "dxfId")))       r->dxf_id      = (int)strtol(v, NULL, 10);
-                if ((v = lxlsx_reader_xml_attr(attrs, "rank")))        r->rank        = strtod(v, NULL);
+                if ((v = lxlsx_reader_xml_attr(attrs, "rank")))        r->rank        = lxlsx_strtod(v, NULL);
                 if ((v = lxlsx_reader_xml_attr(attrs, "text")))        r->text        = strdup(v);
                 if ((v = lxlsx_reader_xml_attr(attrs, "timePeriod")))  r->time_period = strdup(v);
                 r->stop_if_true = attr_truthy(lxlsx_reader_xml_attr(attrs, "stopIfTrue"));
@@ -13908,7 +13908,7 @@ static void m_on_start(void *ud, const char *name, const char **attrs)
                 if (rm) {
                     if (ht) {
                         rm->has_height = 1;
-                        rm->height = strtod(ht, NULL);
+                        rm->height = lxlsx_strtod(ht, NULL);
                     }
                     rm->hidden        = attr_truthy(hidden);
                     rm->outline_level = ol ? (int)strtol(ol, NULL, 10) : 0;

--- a/library/libxlsx/src/xmlwriter.c
+++ b/library/libxlsx/src/xmlwriter.c
@@ -542,6 +542,8 @@ lxlsx_new_attribute_str(const char *key, const char *value)
 {
     struct lxlsx_xml_attribute *attribute = malloc(sizeof(struct lxlsx_xml_attribute));
 
+    if (!attribute) return NULL;
+
     LXLSX_ATTRIBUTE_COPY(attribute->key, key);
     LXLSX_ATTRIBUTE_COPY(attribute->value, value);
 
@@ -554,6 +556,8 @@ lxlsx_new_attribute_int(const char *key, int32_t value)
 {
     struct lxlsx_xml_attribute *attribute = malloc(sizeof(struct lxlsx_xml_attribute));
 
+    if (!attribute) return NULL;
+
     LXLSX_ATTRIBUTE_COPY(attribute->key, key);
     lxlsx_snprintf(attribute->value, LXLSX_MAX_ATTRIBUTE_LENGTH, "%d", value);
 
@@ -565,6 +569,8 @@ struct lxlsx_xml_attribute *
 lxlsx_new_attribute_dbl(const char *key, double value)
 {
     struct lxlsx_xml_attribute *attribute = malloc(sizeof(struct lxlsx_xml_attribute));
+
+    if (!attribute) return NULL;
 
     LXLSX_ATTRIBUTE_COPY(attribute->key, key);
     lxlsx_sprintf_dbl(attribute->value, value);


### PR DESCRIPTION
## Fixes

**Data corruption**
- `read.c` `nextCellCallback` dispatched numeric cells on `_double > 0`, so a negative or zero decimal (e.g. `-5.5`) left `_long` at 0 and was delivered as `0`. Dispatch on the `is_numeric_string()` kind instead, matching `excel.c`.

**Formula-engine DoS (untrusted input via `evaluateFormula`)**
- The recursive-descent parser had no depth limit — deeply nested parens / unary `-` / function args could overflow the C stack. Added a nesting-depth cap.
- Cap the source formula length up front, which also bounds AST size and thus `eval()`/`node_free()` recursion on flat left-leaning trees like `1+1+1+...`.
- The range aggregate had no bound — `SUM(A1:XFD1048576)` would spin through ~1.7e10 resolver calls. It now surfaces `#NUM!` instead.

**NULL-deref on allocation failure**
- `lxlsx_new_attribute_str/int/dbl` (the shared attribute path for every XML writer) dereferenced an unchecked `malloc`; return NULL on OOM and let the push macros skip a NULL attribute.
- The chart reader set `series_count` from the source even when the series `calloc` failed, so the callback could walk a NULL array; keep count consistent with the pointer.

**Locale-independent number handling**
- The writer already formats with a locale-independent dtoa, but reader-side `strtod` and the edit/formula `printf` calls still honoured `LC_NUMERIC`. Under a `,`-decimal host locale the reader parsed `"3.14"` as `3` (cell values, row heights, column widths, font sizes, margins, tints), and edit/formula mode wrote `"3,14"` into the xlsx. Added `lxlsx_strtod` (fast path is a plain `strtod` in the C locale), routed every reader-side `strtod` through it, and format the edit/formula sites via `lxlsx_sprintf_dbl`.

## Testing

- All **184 PHPT tests** pass; output is byte-identical in the default locale.
- Verified end-to-end under `de_DE.UTF-8` (`,` decimal separator): negative-decimal read-back, the DoS guards (100k-deep parens / unary chain / huge range all return an error in 0ms without crashing), and the write / read-back / edit-mode (number, row height, font size) / formula-evaluation paths all keep `.` decimals.
