### PR TITLE
release(3.0.0): version bump, notes and manifest

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -33,11 +33,11 @@
   <email>wjx@php.net</email>
   <active>yes</active>
  </lead>
- <date>2026-06-14</date>
- <time>11:59:31</time>
+ <date>2026-07-05</date>
+ <time>00:00:00</time>
  <version>
-  <release>2.0.3</release>
-  <api>2.0.3</api>
+  <release>3.0.0</release>
+  <api>3.0.0</api>
  </version>
  <stability>
   <release>stable</release>
@@ -45,15 +45,14 @@
  </stability>
  <license uri="https://github.com/viest/php-ext-excel-export/blob/master/LICENSE">BSD license</license>
  <notes>
-- Feature: autoSize(?string $range = null) sizes columns to fit their content. Column widths are estimated from the written cell values (wide/CJK code points count as two columns) and applied at output() time. Tracking is opt-in (call autoSize() before the writes it should size), so writes that never use it pay no per-cell cost; widths are clamped to Excel&apos;s 255 max (#305 / #514).
-- Performance: worksheet metadata (merges, hyperlinks, protection, row/col options) is now loaded lazily instead of eagerly at openSheet(), so data-only reads (getSheetData / nextRow / nextCellCallback / putCSV) skip the second full XML pass — about 40% faster on large sheets.
-- Performance: merge-follow lookups (SKIP_MERGED_FOLLOW) are indexed by last_row with a forward cursor, turning the per-cell scan from O(cells × merges) into amortised near-O(1).
-- Fix: RichString leaked one zend_string per instance (the constructor&apos;s zend_string_copy was never released) and its fetch-object offset pointed at the wrong struct; both corrected.
-- Fix: the cell/row-end/image/comment/chart callback bridges no longer zval_ptr_dtor an uninitialised return value when a callback throws or the call fails.
-- Fix: xlsx_to_csv leaked its temp row on the write-failure path; openFile() now resets reader bookkeeping the way openSheet() and the dtor do; fileName()/constMemory() handle workbook/worksheet allocation failure instead of dereferencing NULL.
-- Fix: the reader now reads every image from drawing.xml instead of stopping after the first 64 KB.
-- Fix: PHP 8.6 compatibility — XtOffsetOf replaced with the standard offsetof, and zval_dtor with zval_ptr_dtor_nogc.
-- Fix: setColumn()/setRow() leaked the per-call row/col options struct, and insertImage() leaked the path zend_string (#573).
+- Feature: formula calculation. evaluateFormula(string $formula) evaluates an Excel formula and returns its result — operator precedence and arithmetic, cell and range references (A1, A1:A3) resolved against the values already written, aggregates (SUM / AVERAGE / MIN / MAX / COUNT / COUNTA), and logical/text functions (IF, CONCATENATE, UPPER, LEN, ...), with Excel error values (#DIV/0!, #NUM!, ...) surfaced as strings. computeFormula(bool $enable = true) opts the workbook into caching, so insertFormula() writes the computed &lt;v&gt; result into the file and other readers see the value without recalculating.
+- Feature: round-trip editing of an existing workbook. openFile() a saved .xlsx and change it in place — cell values, styles, merged ranges, dates and sheet dimensions — add new worksheets, and insert images and charts into the opened workbook, then output() the result. The existing write methods (insertText / insertImage / insertChart / mergeCells / setRow / addSheet, ...) work unchanged in edit mode; unsupported edit operations are now reported instead of being silently dropped.
+- Performance: normal-mode (non constant_memory) export is about 27% faster with roughly 18% lower peak memory; the constant_memory streaming path gained an integer fast-path that skips float formatting for whole-number cells.
+- Fix: the reader returned 0 for negative or zero decimals read through nextCellCallback (the numeric branch was selected on the sign of the value instead of its parsed type); negative and fractional values now read back correctly.
+- Fix: locale independence. Numbers are written and parsed with a &apos;.&apos; decimal point regardless of the host LC_NUMERIC, so using the extension under a &apos;,&apos;-decimal locale (for example after setlocale(LC_ALL, &apos;de_DE&apos;)) no longer corrupts written values or misreads cell values, row heights, column widths and font sizes.
+- Fix: the formula engine is hardened against malformed or hostile input passed to evaluateFormula — deeply nested or over-long expressions can no longer overflow the stack, and an oversized range aggregate such as SUM(A1:XFD1048576) returns #NUM! instead of hanging.
+- Fix: numerous memory-safety and robustness corrections across the reader, the edit path and XML output, including NULL-dereference guards on allocation failure.
+- Note: 3.0.0 is a major release — the reader and writer now share a single unified core alongside the new formula and round-trip editing engines above. All existing class methods, signatures and Excel::* / Format::* constant values are unchanged, so upgrading requires no code changes.
  </notes>
  <contents>
   <dir name="/">
@@ -64,33 +63,33 @@
    <file md5sum="3f481087785cc2dc2c58860d4f26dcd5" name="include/excel.h" role="src" />
    <file md5sum="f978ec80ac4b557aba6d0fab4595feae" name="include/exception.h" role="src" />
    <file md5sum="f1c0ffcea0630cf45feb0614724df338" name="include/format.h" role="src" />
-   <file md5sum="5eae6e23f4a86df6b1ff5228772f5a79" name="include/help.h" role="src" />
-   <file md5sum="aee0af4325b161dd435e5ed5efbacb84" name="include/read.h" role="src" />
+   <file md5sum="8086a708637a03c1329d493071a6aef1" name="include/help.h" role="src" />
+   <file md5sum="818af33ae01d1e2e563ae6c290904a30" name="include/read.h" role="src" />
    <file md5sum="af7e6721a2328f8b9feb9d7f2523e23a" name="include/rich_string.h" role="src" />
    <file md5sum="171dfb294523df3de00a3159140ac2d5" name="include/table.h" role="src" />
    <file md5sum="0654817791a6f7eb06618a39f90d6c71" name="include/validation.h" role="src" />
-   <file md5sum="e5658b7c7169db7205984cfd773d3095" name="include/xlswriter.h" role="src" />
+   <file md5sum="6853c27b3d622dd96b41c386e3262658" name="include/xlswriter.h" role="src" />
    <file md5sum="28447c52eaceb65ca212eeb694159ab7" name="include/minizip/ioapi.h" role="src" />
    <file md5sum="11ae6a9d654c95c47da55fe16772a1e5" name="include/minizip/unzip.h" role="src" />
-   <file md5sum="2e3cd292e23a382b2475d06e4ae4a885" name="kernel/chart.c" role="src" />
-   <file md5sum="5c3d90f3a7c875a243efebf24f6d9d9c" name="kernel/common.c" role="src" />
-   <file md5sum="29c7fd2320390f64d152ac9c547f967c" name="kernel/conditional_format.c" role="src" />
+   <file md5sum="ccbbdff9b7884eae49d2192d347835e9" name="kernel/chart.c" role="src" />
+   <file md5sum="61bd69a5029fe82a0bd6d27ddf3a8ac3" name="kernel/common.c" role="src" />
+   <file md5sum="2ab58b6fb2c569e8e299f7295d6c85d8" name="kernel/conditional_format.c" role="src" />
    <file md5sum="8b5506502769a29b45eea09ba2451ac6" name="kernel/csv.c" role="src" />
-   <file md5sum="d9fcb1a6aa3c0c1865b1c6348f79e2bc" name="kernel/excel.c" role="src" />
+   <file md5sum="98f8609c8ea0008dbaa1eac8d31f670f" name="kernel/excel.c" role="src" />
    <file md5sum="258ee9420b6b692102253f91916a5c7e" name="kernel/exception.c" role="src" />
-   <file md5sum="d61485682738c831b5877ac8306ad8f4" name="kernel/format.c" role="src" />
+   <file md5sum="86adc40985f12ac2df28282833f9c14d" name="kernel/format.c" role="src" />
    <file md5sum="b9ac064adaedd7671a60167db3699592" name="kernel/formula_ast.c" role="src" />
-   <file md5sum="8eee653c04a0ddc79caa83769a293dbf" name="kernel/help.c" role="src" />
-   <file md5sum="79c24cca8103dd22d2b2029ccaf2774e" name="kernel/read.c" role="src" />
-   <file md5sum="ee5fadbf378fe88991499899898fc72a" name="kernel/resource.c" role="src" />
+   <file md5sum="39263e699bc451b521e22b098a23d252" name="kernel/help.c" role="src" />
+   <file md5sum="1b0d672623932a127f1b8b5881fc416d" name="kernel/read.c" role="src" />
+   <file md5sum="95333d0b77eac2ede04fd4d072b5de7f" name="kernel/resource.c" role="src" />
    <file md5sum="223da350126442b72f6751acd1b2e0a8" name="kernel/rich_string.c" role="src" />
-   <file md5sum="306c06f97c1cd359bd8daefa0c8f3206" name="kernel/table.c" role="src" />
-   <file md5sum="108c28b2d78187241704c94b6cdbe7ec" name="kernel/validation.c" role="src" />
-   <file md5sum="234036c206d3e51c6fa6bf27bd485bfc" name="kernel/write.c" role="src" />
+   <file md5sum="46942437b68d7d2d3ccc7b1a21adb47f" name="kernel/table.c" role="src" />
+   <file md5sum="c9da55fa60c45c2100038876c59ee539" name="kernel/validation.c" role="src" />
+   <file md5sum="22619df97f61415a57efab35daabc416" name="kernel/write.c" role="src" />
    <file md5sum="913339bdbd804e7459af447b0030f45b" name="library/libxlsx/include/libxlsx.h" role="src" />
    <file md5sum="e37d137187e407f1522967812a2634d3" name="library/libxlsx/include/libxlsx/app.h" role="src" />
-   <file md5sum="bbbca61627a12946671086ef8859c975" name="library/libxlsx/include/libxlsx/cell.h" role="src" />
-   <file md5sum="ef97082d98537b36c511289d13b1261c" name="library/libxlsx/include/libxlsx/chart.h" role="src" />
+   <file md5sum="0ac2ccc22c2b3cceac07f635db4ce36c" name="library/libxlsx/include/libxlsx/cell.h" role="src" />
+   <file md5sum="eb44c038c0dbfb3ad702dc1bd1e35701" name="library/libxlsx/include/libxlsx/chart.h" role="src" />
    <file md5sum="8fd398cf14116e4a2b3b484df1d37226" name="library/libxlsx/include/libxlsx/chartsheet.h" role="src" />
    <file md5sum="45051e3fb5fe99e21ed0a8b050ba3cac" name="library/libxlsx/include/libxlsx/comment.h" role="src" />
    <file md5sum="8c9e1fa6787e395774cae3efd073607b" name="library/libxlsx/include/libxlsx/common.h" role="src" />
@@ -98,25 +97,23 @@
    <file md5sum="1fdb3286d74d4144d733cbe2474b8080" name="library/libxlsx/include/libxlsx/core.h" role="src" />
    <file md5sum="a8b483b362204f19836584d704f2e72e" name="library/libxlsx/include/libxlsx/custom.h" role="src" />
    <file md5sum="a879eefb1115040166cd9612d68e95d9" name="library/libxlsx/include/libxlsx/drawing.h" role="src" />
-   <file md5sum="1b4f39f3603b85a450427a64704c7a58" name="library/libxlsx/include/libxlsx/edit.h" role="src" />
+   <file md5sum="fae5c8b62d7e879be9c7c11bda617d81" name="library/libxlsx/include/libxlsx/edit.h" role="src" />
    <file md5sum="51a21d160d95f21a0be6c03ef3144d45" name="library/libxlsx/include/libxlsx/format.h" role="src" />
-   <file md5sum="5151f9f3c87ee4738f59690a0fec7766" name="library/libxlsx/include/libxlsx/hash_table.h" role="src" />
+   <file md5sum="b417b93ffba111547d733b8b2b5557b1" name="library/libxlsx/include/libxlsx/formula.h" role="src" />
+   <file md5sum="b288aa4012593b7edc82a7395a1208bc" name="library/libxlsx/include/libxlsx/hash_table.h" role="src" />
    <file md5sum="9fdb9b053552e276dc5290ea98b01b0b" name="library/libxlsx/include/libxlsx/metadata.h" role="src" />
    <file md5sum="c08eeefcb68e6063086fa2fa357b1bb9" name="library/libxlsx/include/libxlsx/packager.h" role="src" />
    <file md5sum="c479ec755d4bf38d545a3e8319595726" name="library/libxlsx/include/libxlsx/reader.h" role="src" />
-   <file md5sum="8c9e1fa6787e395774cae3efd073607b" name="library/libxlsx/include/libxlsx/common.h" role="src" />
-   <file md5sum="a879eefb1115040166cd9612d68e95d9" name="library/libxlsx/include/libxlsx/drawing.h" role="src" />
    <file md5sum="c3e0a79788fd2eef038ff606f1686c60" name="library/libxlsx/include/libxlsx/styles.h" role="src" />
-   <file md5sum="3c19c93e82ab721a1d4284fc60c1666f" name="library/libxlsx/include/libxlsx/workbook.h" role="src" />
-   <file md5sum="e0c1fd7d1294555f21e39d9b99ac2f1c" name="library/libxlsx/include/libxlsx/worksheet.h" role="src" />
+   <file md5sum="b1a260b05b51d31a27b3cef64e49c0cc" name="library/libxlsx/include/libxlsx/workbook.h" role="src" />
+   <file md5sum="f8307a1b42ecfe74a28143e6adc75959" name="library/libxlsx/include/libxlsx/worksheet.h" role="src" />
    <file md5sum="507afbba00a123ef8729cffbae14f8e8" name="library/libxlsx/include/libxlsx/relationships.h" role="src" />
    <file md5sum="831fb98067a0234d5b88f70b96112403" name="library/libxlsx/include/libxlsx/rich_value.h" role="src" />
    <file md5sum="c3a778b4292ed1f20629efa2a92f8c0f" name="library/libxlsx/include/libxlsx/rich_value_rel.h" role="src" />
    <file md5sum="ddc2de57d2031d0ef44bb70a44e02c39" name="library/libxlsx/include/libxlsx/rich_value_structure.h" role="src" />
    <file md5sum="c9b50eb3e014f28fbd66b89fba721bff" name="library/libxlsx/include/libxlsx/rich_value_types.h" role="src" />
-   <file md5sum="6f199b6d2b8175b69b2a7fa7d844791d" name="library/libxlsx/include/libxlsx/shared_strings.h" role="src" />
-   <file md5sum="eea6fe75f32dc497ea2fe81430786520" name="library/libxlsx/include/libxlsx/source_package.h" role="src" />
-   <file md5sum="c3e0a79788fd2eef038ff606f1686c60" name="library/libxlsx/include/libxlsx/styles.h" role="src" />
+   <file md5sum="d71ca34f0e37709b19d2805c5fcc2bcf" name="library/libxlsx/include/libxlsx/shared_strings.h" role="src" />
+   <file md5sum="8da834e931d62f6fb1a079d4dcce583e" name="library/libxlsx/include/libxlsx/source_package.h" role="src" />
    <file md5sum="8616bfeee590ac49d8c50551467e5279" name="library/libxlsx/include/libxlsx/table.h" role="src" />
    <file md5sum="b32a1a1914617f599c106095b5b59e98" name="library/libxlsx/include/libxlsx/theme.h" role="src" />
    <file md5sum="101b28445cb2dae2e73cd0763bc79d77" name="library/libxlsx/include/libxlsx/third_party/emyg_dtoa.h" role="src" />
@@ -126,11 +123,9 @@
    <file md5sum="91ecc39f822ba460d99a451fec030cfa" name="library/libxlsx/include/libxlsx/third_party/tmpfileplus.h" role="src" />
    <file md5sum="de224c89e67700652f117cab66f4acbb" name="library/libxlsx/include/libxlsx/third_party/tree.h" role="src" />
    <file md5sum="f05fbca3975c1eee17671e3cb5842fd6" name="library/libxlsx/include/libxlsx/third_party/zip.h" role="src" />
-   <file md5sum="613335356e979830328cfc4f4e7f8fb9" name="library/libxlsx/include/libxlsx/utility.h" role="src" />
+   <file md5sum="1b3261c0306c34fa073ef63d11bf02d5" name="library/libxlsx/include/libxlsx/utility.h" role="src" />
    <file md5sum="d4a26284577a2c9442b24ec338d26eda" name="library/libxlsx/include/libxlsx/vml.h" role="src" />
-   <file md5sum="3c19c93e82ab721a1d4284fc60c1666f" name="library/libxlsx/include/libxlsx/workbook.h" role="src" />
-   <file md5sum="e0c1fd7d1294555f21e39d9b99ac2f1c" name="library/libxlsx/include/libxlsx/worksheet.h" role="src" />
-   <file md5sum="29d71f4f7d2a0293ef61e2909d2449e0" name="library/libxlsx/include/libxlsx/xmlwriter.h" role="src" />
+   <file md5sum="d1c2c908d714c8451edcb8a2bbda8520" name="library/libxlsx/include/libxlsx/xmlwriter.h" role="src" />
    <file md5sum="fd6f0dc8462674bef9be5c0c85bffaa2" name="library/libxlsx/third_party/dtoa/emyg_dtoa.c" role="src" />
    <file md5sum="101b28445cb2dae2e73cd0763bc79d77" name="library/libxlsx/third_party/dtoa/emyg_dtoa.h" role="src" />
    <file md5sum="4d6bbe6eab64e6a0b90ea116883c1fe7" name="library/libxlsx/third_party/md5/md5.c" role="src" />
@@ -150,47 +145,48 @@
    <file md5sum="f05fbca3975c1eee17671e3cb5842fd6" name="library/libxlsx/third_party/minizip/zip.h" role="src" />
    <file md5sum="636907d331156d62e8e750411db3a87b" name="library/libxlsx/third_party/tmpfileplus/tmpfileplus.c" role="src" />
    <file md5sum="91ecc39f822ba460d99a451fec030cfa" name="library/libxlsx/third_party/tmpfileplus/tmpfileplus.h" role="src" />
-   <file md5sum="9a52976f153994602ca1d35cc721f428" name="library/libxlsx/src/app.c" role="src" />
-   <file md5sum="ca6772b4606dd7a5ea68dbd828d4c0f1" name="library/libxlsx/src/chart.c" role="src" />
-   <file md5sum="55c797d57fccdd3afc1af148dd5a92df" name="library/libxlsx/src/chartsheet.c" role="src" />
-   <file md5sum="e4290e3daee4f59c7f56b96a684f7a5b" name="library/libxlsx/src/comment.c" role="src" />
-   <file md5sum="32323692176b7c7579efcea76eeb0c68" name="library/libxlsx/src/content_types.c" role="src" />
-   <file md5sum="c2bddca4fe4deee6701b139aa56b8134" name="library/libxlsx/src/core.c" role="src" />
-   <file md5sum="ef923281409c9347a0bfcfd9343a5071" name="library/libxlsx/src/custom.c" role="src" />
-   <file md5sum="bab77e081d8f21a02d3901f1b0601dd7" name="library/libxlsx/src/drawing.c" role="src" />
-   <file md5sum="ebdd9c6b59d1059b698285a4a780e723" name="library/libxlsx/src/edit.c" role="src" />
+   <file md5sum="443cbc83f431057d64337f730d12c2a6" name="library/libxlsx/src/app.c" role="src" />
+   <file md5sum="f2810a63f6268c0c035167d4ef4087d6" name="library/libxlsx/src/chart.c" role="src" />
+   <file md5sum="d900125b9da9d007c4901a38025c9a06" name="library/libxlsx/src/chartsheet.c" role="src" />
+   <file md5sum="d939cfb454c5ae40be634f5a684209c3" name="library/libxlsx/src/comment.c" role="src" />
+   <file md5sum="ae4444dd06122397d9394f9adaac9b64" name="library/libxlsx/src/content_types.c" role="src" />
+   <file md5sum="2ec8a2c91e276224e0073b638a4ce309" name="library/libxlsx/src/core.c" role="src" />
+   <file md5sum="32cb81a8c1199f52f3ecdd154322e385" name="library/libxlsx/src/custom.c" role="src" />
+   <file md5sum="91fe8ea78edca4fd9d988f1a413139bb" name="library/libxlsx/src/drawing.c" role="src" />
+   <file md5sum="f35d4d31ca77f50599899c6dff2121d2" name="library/libxlsx/src/edit.c" role="src" />
    <file md5sum="53afa85e00100506e020be0076a4c871" name="library/libxlsx/src/format.c" role="src" />
-   <file md5sum="b8d828a9f72d83b97ef6657c84f555cc" name="library/libxlsx/src/hash_table.c" role="src" />
-   <file md5sum="ce8c9dddc97809151f937b8632c643ae" name="library/libxlsx/src/metadata.c" role="src" />
-   <file md5sum="bb9899dfb63afd654576b7ef3528ddd8" name="library/libxlsx/src/packager.c" role="src" />
-   <file md5sum="2b7c92b5aa5dae69fd8e03896aff08d3" name="library/libxlsx/src/relationships.c" role="src" />
-   <file md5sum="a9e8aae0ab9f71ae85f3bdb6f92c2ca2" name="library/libxlsx/src/rich_value.c" role="src" />
-   <file md5sum="5ff3f7026e158580142498fbbb5e8fc6" name="library/libxlsx/src/rich_value_rel.c" role="src" />
-   <file md5sum="9988f521d03fd044e7890696f6bf4709" name="library/libxlsx/src/rich_value_structure.c" role="src" />
-   <file md5sum="9283f2e3d6c968e7f4df189cafa58504" name="library/libxlsx/src/rich_value_types.c" role="src" />
-   <file md5sum="cbe1832eac227052eb91404bb45a3e9f" name="library/libxlsx/src/shared_strings.c" role="src" />
-   <file md5sum="e445e68ce6e71680f43c84912ecaac29" name="library/libxlsx/src/source_package.c" role="src" />
-   <file md5sum="4e70fb5e1d761e90e7b606a864703ff3" name="library/libxlsx/src/styles.c" role="src" />
-   <file md5sum="fa4460cd2bf9c4b3105f44ea5ab0cf72" name="library/libxlsx/src/table.c" role="src" />
+   <file md5sum="1a241761dcaf0472f39e775741eab734" name="library/libxlsx/src/formula.c" role="src" />
+   <file md5sum="e91de59173cc80288b745d6381235ac9" name="library/libxlsx/src/hash_table.c" role="src" />
+   <file md5sum="8047eca8f7571d7d32eaf1d7180b4cb0" name="library/libxlsx/src/metadata.c" role="src" />
+   <file md5sum="7983b3c6d4d9a4e75d94f3a05b7a1863" name="library/libxlsx/src/packager.c" role="src" />
+   <file md5sum="7bafb2f33bf9a9d8fc905d02dfb3b043" name="library/libxlsx/src/relationships.c" role="src" />
+   <file md5sum="b081873e97e03a4c12a5dce6d8ec1a70" name="library/libxlsx/src/rich_value.c" role="src" />
+   <file md5sum="d5fd0b40db795b3d969c6eb21ab7becc" name="library/libxlsx/src/rich_value_rel.c" role="src" />
+   <file md5sum="3d1a307f67f56821656ab42efae8566b" name="library/libxlsx/src/rich_value_structure.c" role="src" />
+   <file md5sum="2bbf6c040ea305bdfe6d073feaf106cd" name="library/libxlsx/src/rich_value_types.c" role="src" />
+   <file md5sum="a244ebc5308f72f60f7600120533a1ff" name="library/libxlsx/src/shared_strings.c" role="src" />
+   <file md5sum="503e52cd2ee54d8e8916c817562c49f8" name="library/libxlsx/src/source_package.c" role="src" />
+   <file md5sum="3c288e8c95d2000dcabf53488b826c32" name="library/libxlsx/src/styles.c" role="src" />
+   <file md5sum="1046b7b8135f2798bb34c9855cc45779" name="library/libxlsx/src/table.c" role="src" />
    <file md5sum="070505f0c5bca894e81e5d95df16b8fd" name="library/libxlsx/src/theme.c" role="src" />
-   <file md5sum="f89d67e914f9123fd700a50bf1582366" name="library/libxlsx/src/utility.c" role="src" />
+   <file md5sum="7e20eda5e501152f9628b0058297870d" name="library/libxlsx/src/utility.c" role="src" />
    <file md5sum="dcd595cfdadf4c42e18681396353c96f" name="library/libxlsx/src/vml.c" role="src" />
-   <file md5sum="21a7159d79a199f46b911dc11b224beb" name="library/libxlsx/src/workbook.c" role="src" />
-   <file md5sum="7c375889286c20bcbc9f519a51812b4f" name="library/libxlsx/src/worksheet.c" role="src" />
-   <file md5sum="524467cf686a908261efcd726d7d2468" name="library/libxlsx/src/xmlwriter.c" role="src" />
+   <file md5sum="9806c3d1038ec05a9784034c49e82455" name="library/libxlsx/src/workbook.c" role="src" />
+   <file md5sum="e06cbe89363073f284c5e4c479415e9a" name="library/libxlsx/src/worksheet.c" role="src" />
+   <file md5sum="aa545b6c4e0eb0e321fd0d771a10ba36" name="library/libxlsx/src/xmlwriter.c" role="src" />
    <file md5sum="61acc0b9f0e317dd7729072e75dc5ed9" name="library/libxlsx/src/common.c" role="src" />
-   <file md5sum="9dd065d44f4287cfd31ebf2f4f94d79b" name="library/libxlsx/internal/platform.h" role="src" />
-   <file md5sum="f01bb2ea49ebef9d428110d4133d4118" name="library/libxlsx/internal/xlsx_private.h" role="src" />
+   <file md5sum="c42eb34634713caa9fe4096767b9864d" name="library/libxlsx/internal/platform.h" role="src" />
+   <file md5sum="a6b7ca1ee3f398c4e92880d18849fae5" name="library/libxlsx/internal/xlsx_private.h" role="src" />
    <file md5sum="4ddff1ddad00eef338733c013a5b7c36" name="library/libxlsx/internal/numfmt.h" role="src" />
    <file md5sum="10c185458313c1c2a781a0b27ea9551e" name="library/libxlsx/internal/sst.h" role="src" />
    <file md5sum="d172142fcdb984617a87cf91d688e37f" name="library/libxlsx/internal/styles_private.h" role="src" />
-   <file md5sum="9548dda724c15d294ea83cb5a00d67ff" name="library/libxlsx/internal/xlsx_util.h" role="src" />
+   <file md5sum="4b1117f706b08d794e55bbc40db61f85" name="library/libxlsx/internal/xlsx_util.h" role="src" />
    <file md5sum="9eea433b4ae67c2cf6030ba894b80f97" name="library/libxlsx/internal/xml_pump.h" role="src" />
-   <file md5sum="8be4fa05a13b4b2257f13ea6af7830a6" name="library/libxlsx/internal/zip_io.h" role="src" />
-   <file md5sum="7da8cf261c0ca5fc370c3418d3f57601" name="library/libxlsx/src/sst.c" role="src" />
-   <file md5sum="ce4843a76f647fdcb220e54c557b7887" name="library/libxlsx/src/xlsx_util.c" role="src" />
-   <file md5sum="bfbbeb6facf3f67fb1b74d7c12b588ff" name="library/libxlsx/src/xml_pump.c" role="src" />
-   <file md5sum="c2c2905695043a20176c38e2c5b02a5f" name="library/libxlsx/src/zip_io.c" role="src" />
+   <file md5sum="da6c507715840ae3467d217763dde32d" name="library/libxlsx/internal/zip_io.h" role="src" />
+   <file md5sum="be0c783e567ac4947a6a941de38bfd69" name="library/libxlsx/src/sst.c" role="src" />
+   <file md5sum="0043a2509b8f08454daf687afd431bdc" name="library/libxlsx/src/xlsx_util.c" role="src" />
+   <file md5sum="24ffd5b9e7e8a7133428764268c19231" name="library/libxlsx/src/xml_pump.c" role="src" />
+   <file md5sum="81b5c496edf014694ed69248164dd5e0" name="library/libxlsx/src/zip_io.c" role="src" />
    <file md5sum="90121909ee7cfe8020acab7f4a92bfec" name="library/libxlsx/License.txt" role="doc" />
    <file md5sum="06c903b655d2c8d400216d720835a831" name="library/libxlsx/README.md" role="doc" />
    <file md5sum="01baabba632bd8a07926ec8207b1a9a0" name="library/libexpat/expat/lib/ascii.h" role="src" />
@@ -219,7 +215,7 @@
    <file md5sum="f27a98466d7df8685391e3b152b729e2" name="resource/logo.png" role="src" />
    <file md5sum="abf8819a114cf714d9b6253b5525758c" name="resource/logo_now.png" role="src" />
    <file md5sum="4844382fe6fc15baa77668ba414a8f58" name="resource/pecl.png" role="src" />
-   <file md5sum="e681a16cd265db9f841239123f0dabf4" name="resource/performance_comparison.png" role="src" />
+   <file md5sum="616a9d9f318e91f65a8363109479c9de" name="resource/performance_comparison.png" role="src" />
    <file md5sum="e68d06faed0c581ad9f3906f6a917d18" name="examples/01_basic_write.php" role="doc" />
    <file md5sum="ec366c1deb689bf231379860293441c1" name="examples/02_read_full.php" role="doc" />
    <file md5sum="202d701ec3fbc7e574363ab06901c700" name="examples/03_read_streaming.php" role="doc" />
@@ -245,7 +241,7 @@
    <file md5sum="d6d9d66918789c1fd175b5871f5bef5e" name="tests/011.phpt" role="test" />
    <file md5sum="a1312f0a3f65de3ef70cb3383adac3b7" name="tests/012.phpt" role="test" />
    <file md5sum="c5607abe7fd03228610ed5cd276f71e1" name="tests/013.phpt" role="test" />
-   <file md5sum="7ea4226930d53d28981f43a93347649d" name="tests/014.phpt" role="test" />
+   <file md5sum="67bc9b8735dffb8a183f83f6fc947b12" name="tests/014.phpt" role="test" />
    <file md5sum="afd05784669808b97b245fe651c938ee" name="tests/015.phpt" role="test" />
    <file md5sum="3f1cf31e90aa130ef3ef2b35deb1efa7" name="tests/016.phpt" role="test" />
    <file md5sum="af77bc53a5eecfd55278db4f5218db0a" name="tests/018.phpt" role="test" />
@@ -262,19 +258,28 @@
    <file md5sum="49892fb028971b85b76b5b09b11c4915" name="tests/chart_title.phpt" role="test" />
    <file md5sum="d172e28040e8ad6986c025d47fcf05b9" name="tests/close.phpt" role="test" />
    <file md5sum="9badb50b14bd81536bafcfefcb5677d6" name="tests/column_index_from_string.phpt" role="test" />
+   <file md5sum="427bb6abef60bec3fa20720ac1038e91" name="tests/compute_formula.phpt" role="test" />
    <file md5sum="9312ea50406f84839500e9f43733642e" name="tests/conditional_format.phpt" role="test" />
    <file md5sum="c4b58a9354ebd3f4a6c3b264bb5d153c" name="tests/const_memory.phpt" role="test" />
-   <file md5sum="df51cba59eca3dab801f61b43a9b8652" name="tests/empty_sheet_name.phpt" role="test" />
    <file md5sum="d73f6524f34f3866e1c4319cf41c2415" name="tests/const_memory_index_out_range.phpt" role="test" />
+   <file md5sum="ff0aa56694715d13f5bd9a395b1a37d7" name="tests/const_memory_stream_roundtrip.phpt" role="test" />
+   <file md5sum="5dd8d847353c70d8db47daeefd111b47" name="tests/construct_rejects_empty_path.phpt" role="test" />
    <file md5sum="c2e7248f1c17d651d07054f0567e01f7" name="tests/data_reference.phpt" role="test" />
    <file md5sum="3373c902b38d79f8c5cb496126300089" name="tests/data_string_key.phpt" role="test" />
    <file md5sum="bbfb0076139d7f38122ad3fbabd137d9" name="tests/default_format.phpt" role="test" />
    <file md5sum="c9f07f633864094c4d260fc8ba98f3d1" name="tests/define_name_round_trip.phpt" role="test" />
+   <file md5sum="1120eef33155a67f355ef0c25b52b22c" name="tests/edit_dimensions.phpt" role="test" />
+   <file md5sum="9d2ed8e3d90411e7f51d48e38acc34d9" name="tests/edit_insert_date.phpt" role="test" />
+   <file md5sum="056b9fcceb84ad42ae7a379a4bc5ada4" name="tests/edit_merge.phpt" role="test" />
+   <file md5sum="6fa747478d04f325ab44b3dba9eaa88e" name="tests/edit_restyle.phpt" role="test" />
+   <file md5sum="df51cba59eca3dab801f61b43a9b8652" name="tests/empty_sheet_name.phpt" role="test" />
+   <file md5sum="6d96b405670c3e1167428589f241e260" name="tests/evaluate_formula.phpt" role="test" />
    <file md5sum="bfade0223128549c647c7a9a2004ed79" name="tests/examples_smoke.phpt" role="test" />
    <file md5sum="4de257360d57e624fdb2ad5f8acd97e3" name="tests/exist_sheet.phpt" role="test" />
    <file md5sum="8311c7a9720ff5294d5d2909b2b22ce3" name="tests/first.phpt" role="test" />
    <file md5sum="19774ad9e2802580fe15c0ecea885524" name="tests/fix-207.phpt" role="test" />
    <file md5sum="25d52fbf434183a87055f8166756e500" name="tests/fix-243.phpt" role="test" />
+   <file md5sum="7e951a3a0f428cd13b970daee0060fe9" name="tests/foreign_resource_guard.phpt" role="test" />
    <file md5sum="10208d93b613c22f307fea2e27a6375b" name="tests/format_align.phpt" role="test" />
    <file md5sum="0a54cee9caeb20aa735d716d585b5fa2" name="tests/format_background.phpt" role="test" />
    <file md5sum="215e0433c0e2837cf1abd5cc7c71bffa" name="tests/format_border.phpt" role="test" />
@@ -297,55 +302,99 @@
    <file md5sum="2692d653a1420e4669b7e919fd779dca" name="tests/get_formula_ast.phpt" role="test" />
    <file md5sum="7c61027bec320149bda350ec05a41bb2" name="tests/get_set_current_line.phpt" role="test" />
    <file md5sum="c033c4a4708cdd3f01ca97938752b1c9" name="tests/gridlines.phpt" role="test" />
-   <file md5sum="7db905bd9592d8a63782d345ec5b34f9" name="tests/header_format.phpt" role="test" />
    <file md5sum="d0c520b7ac9c3a5cbef2698a62386717" name="tests/header_after_data.phpt" role="test" />
-   <file md5sum="140da23971943ec94f34a376838bc120" name="tests/insert_date_format_cache.phpt" role="test" />
-   <file md5sum="c0abff1dce8a6700b5157f6bb2a81eb7" name="tests/insert_text_font_with_numfmt.phpt" role="test" />
+   <file md5sum="7db905bd9592d8a63782d345ec5b34f9" name="tests/header_format.phpt" role="test" />
    <file md5sum="3100733302730aa291229bfeb5acea6c" name="tests/hide.phpt" role="test" />
    <file md5sum="8e2253c5a9bfc3dc7279f1d318ce0204" name="tests/image_no_styles.phpt" role="test" />
    <file md5sum="0881d6fcc38d2d35a05fb7ea49c9532b" name="tests/image_width_height_styles.phpt" role="test" />
+   <file md5sum="1af8b7c3064d8e7b2ad50daf4b45c7f0" name="tests/include/skipif.inc" role="test" />
    <file md5sum="d8efead8ab4e730bd6b8726458d2f213" name="tests/insert_comment.phpt" role="test" />
+   <file md5sum="8aa031a9f474460f06a933a83210a047" name="tests/insert_comment_opt.phpt" role="test" />
    <file md5sum="b8b135296813937786f26cc4380cc3b6" name="tests/insert_date_custom_format.phpt" role="test" />
    <file md5sum="46f788bd648003dd23859f13652ba3eb" name="tests/insert_date_default_format.phpt" role="test" />
+   <file md5sum="140da23971943ec94f34a376838bc120" name="tests/insert_date_format_cache.phpt" role="test" />
    <file md5sum="71086b8ee2ab5edc681fd33e85503356" name="tests/insert_date_resource_format.phpt" role="test" />
+   <file md5sum="51c2ebba742e4cbeb7c1731a0a053b75" name="tests/insert_dynamic_array_formula.phpt" role="test" />
+   <file md5sum="75ec45a64b95c50aa4dee75d6956bb4d" name="tests/insert_dynamic_formula.phpt" role="test" />
+   <file md5sum="fd7d985f58a4a2963b60810c9c2ef42a" name="tests/insert_image_buffer.phpt" role="test" />
+   <file md5sum="25858958701fa7a6f075fa580fc75abc" name="tests/insert_image_opt.phpt" role="test" />
+   <file md5sum="c0abff1dce8a6700b5157f6bb2a81eb7" name="tests/insert_text_font_with_numfmt.phpt" role="test" />
    <file md5sum="32704b914c1fb5ce8c215287914a5281" name="tests/insert_text_resource_format.phpt" role="test" />
    <file md5sum="4f58bfd47cf1348e91a9355d7d4e65fc" name="tests/insert_url_format.phpt" role="test" />
    <file md5sum="6c2e5a9a409b9c574168417ec89c5f0f" name="tests/insert_url_no_format.phpt" role="test" />
    <file md5sum="17687fcc382284360e0a1a1ea8cac33d" name="tests/margins.phpt" role="test" />
    <file md5sum="f0aa7a756269bff3f10ea85d4669ea72" name="tests/merge_cell_type_writer.phpt" role="test" />
    <file md5sum="1afb5a7b146f52ec836388f0a9ba780c" name="tests/multiple_file.phpt" role="test" />
+   <file md5sum="6ac77bee273894119f84038548a9b29d" name="tests/narrowing_range_guard.phpt" role="test" />
+   <file md5sum="44ba5b15ae09ce4cab85ec149464db55" name="tests/open_xlsx_edit_add_sheet.phpt" role="test" />
+   <file md5sum="1092d5ae3da08ba8ca6644ca004637c5" name="tests/open_xlsx_edit_insert_chart.phpt" role="test" />
+   <file md5sum="31a23c6fc85c1180cdbad505449eaeac" name="tests/open_xlsx_edit_insert_image.phpt" role="test" />
+   <file md5sum="523c1327f23bb8468f856dfcc7fb6658" name="tests/open_xlsx_edit_template_output.phpt" role="test" />
    <file md5sum="aea162eb9edfcc4ffd79ac86b7e2ec39" name="tests/open_xlsx_file.phpt" role="test" />
    <file md5sum="422c1a35cec224ce59ce83c989cf49d0" name="tests/open_xlsx_file_not_found.phpt" role="test" />
-   <file md5sum="fdf94db3bdd6b0013c1c618fc985793b" name="tests/open_xlsx_edit_template_output.phpt" role="test" />
+   <file md5sum="46e729b298af6c201a24c1ed4940e842" name="tests/open_xlsx_formula_verbose.phpt" role="test" />
+   <file md5sum="3353a285143a96db3ec45a241a8c915c" name="tests/open_xlsx_get_auto_filter.phpt" role="test" />
+   <file md5sum="395d0b0e7cb57dfecf5151832e9ab316" name="tests/open_xlsx_get_conditional_formats.phpt" role="test" />
    <file md5sum="393a280a52af2e809772a512eb2d8168" name="tests/open_xlsx_get_data.phpt" role="test" />
    <file md5sum="fe36e6277d4b188fcb28182a103f286e" name="tests/open_xlsx_get_data_bignumbers.phpt" role="test" />
    <file md5sum="22a1f6b624ff3a3f64efe1e95ea1aad1" name="tests/open_xlsx_get_data_skip_empty.phpt" role="test" />
    <file md5sum="8a68ac792b61701e31b76087bcfee0d5" name="tests/open_xlsx_get_data_skip_hidden_rows.phpt" role="test" />
    <file md5sum="f5e7821650e0c24b3c709ed135a8585a" name="tests/open_xlsx_get_data_skip_rows.phpt" role="test" />
+   <file md5sum="7c92d8e7ffcf052d9f88ac0b0cfd0fbf" name="tests/open_xlsx_get_data_validations.phpt" role="test" />
    <file md5sum="dd0dd48b3540a83539431dda1711f107" name="tests/open_xlsx_get_data_with_set_type.phpt" role="test" />
+   <file md5sum="dd41c30847bc06011dadb15cb899d664" name="tests/open_xlsx_get_defined_names.phpt" role="test" />
+   <file md5sum="704429045f207609b2e740174094fa60" name="tests/open_xlsx_get_hyperlinks.phpt" role="test" />
+   <file md5sum="8ddcb3ef485d7973436cd9d6a5148ad3" name="tests/open_xlsx_get_merged_cells.phpt" role="test" />
+   <file md5sum="221459194da3d455fcdca014a64ab9c4" name="tests/open_xlsx_get_page_setup.phpt" role="test" />
+   <file md5sum="c1fc164190124aac1f730e188e63e8a9" name="tests/open_xlsx_get_row_column_options.phpt" role="test" />
    <file md5sum="600f2c9e264b118a0d5388fa442ee2a4" name="tests/open_xlsx_get_sheet_not_found_data.phpt" role="test" />
+   <file md5sum="b694667e2d5dcfe6c01a122b44f8ab22" name="tests/open_xlsx_get_sheet_protection.phpt" role="test" />
+   <file md5sum="d71bfcbc3f01f654a58aef35a9ee696a" name="tests/open_xlsx_get_style_format.phpt" role="test" />
    <file md5sum="d2b4265460e72fd79ed4ade8017de5af" name="tests/open_xlsx_global_data_type.phpt" role="test" />
+   <file md5sum="a15e3585f8cacd904177893b5f5c44f1" name="tests/open_xlsx_iterate_charts.phpt" role="test" />
+   <file md5sum="f046965eda05c0dfc8b58b1fc4c1fe3a" name="tests/open_xlsx_iterate_comments.phpt" role="test" />
+   <file md5sum="7d5e7becda0f6919384156b21c9af8da" name="tests/open_xlsx_iterate_images.phpt" role="test" />
    <file md5sum="ecc24f87a6dbf5deb3081511bc5a0251" name="tests/open_xlsx_next_cell_callback.phpt" role="test" />
    <file md5sum="a52de2df14773ca385510fc2bb7121c9" name="tests/open_xlsx_next_cell_callback_with_data_type.phpt" role="test" />
    <file md5sum="30e97223fbdfb7585c75547839ebd119" name="tests/open_xlsx_next_row.phpt" role="test" />
+   <file md5sum="7f6d6674941436e3b619bfe804dd0f62" name="tests/open_xlsx_next_row_rich.phpt" role="test" />
    <file md5sum="4612f2af45ef536c4746369a23b38731" name="tests/open_xlsx_next_row_skip_empty.phpt" role="test" />
    <file md5sum="1ce2e72ff811201cf09295f1a6b0f385" name="tests/open_xlsx_next_row_skip_rows.phpt" role="test" />
    <file md5sum="04ca1892839c6045dbbd43372cfae245" name="tests/open_xlsx_next_row_with_data_type_date.phpt" role="test" />
    <file md5sum="a72afcd110d5604fa4ecd384339cf48f" name="tests/open_xlsx_next_row_with_data_type_date_array_index.phpt" role="test" />
    <file md5sum="0503684f9d042eadc2a267355732f7df" name="tests/open_xlsx_next_row_with_data_type_string.phpt" role="test" />
+   <file md5sum="393e6a7b7ceb2d7afc08e25963b4d032" name="tests/open_xlsx_next_row_with_formula.phpt" role="test" />
+   <file md5sum="7df43a3db299df2e52e4305423223d58" name="tests/open_xlsx_next_row_with_formula_url.phpt" role="test" />
    <file md5sum="52f7957516c53e2acb9dd86edd19355b" name="tests/open_xlsx_next_row_with_set_type.phpt" role="test" />
    <file md5sum="da68c45e26996ff404abbd069c08729b" name="tests/open_xlsx_sheet.phpt" role="test" />
    <file md5sum="ed8be6d57de929052b16e8224535497d" name="tests/open_xlsx_sheet_flag.phpt" role="test" />
    <file md5sum="606e1e3886de249f8c3aaedde0373500" name="tests/open_xlsx_sheet_list.phpt" role="test" />
+   <file md5sum="2f6f92e91b110076731aa630d91cd203" name="tests/open_xlsx_sheet_visibility.phpt" role="test" />
+   <file md5sum="bd0bc58aa68b259e3a3096d2466d0ce5" name="tests/open_xlsx_skip_merged_follow.phpt" role="test" />
+   <file md5sum="54671b954c2f32dc5198b3b6c1292d4f" name="tests/open_xlsx_threaded_comments.phpt" role="test" />
+   <file md5sum="1985099f3c2f999cc475c52a4e7dfcca" name="tests/outline_level_column.phpt" role="test" />
+   <file md5sum="a074945aaa6bb0bc0a0849c3804178e7" name="tests/outline_level_column_const_memory.phpt" role="test" />
+   <file md5sum="4c78f2e57d85b1ce7729080be688bc5e" name="tests/outline_level_row.phpt" role="test" />
+   <file md5sum="ec76dd42789d8b19641e4a9cc4df210c" name="tests/outline_level_row_const_memory.phpt" role="test" />
+   <file md5sum="b051fbde4a5777f8a46e2cdb2e2a4738" name="tests/outline_settings.phpt" role="test" />
+   <file md5sum="fb107b0089c2aa55fc305884813e8966" name="tests/page_setup.phpt" role="test" />
    <file md5sum="1ca75a968275818128fe3c585b7407d4" name="tests/paper.phpt" role="test" />
-   <file md5sum="92931db71597f10ec7a05cd6d16d5119" name="tests/printed.phpt" role="test" />
+   <file md5sum="4261d0dc8129e5cbbf18577b91e885af" name="tests/printed.phpt" role="test" />
    <file md5sum="f7481bcce5e19f3705e8cd181d2d06f9" name="tests/protection.phpt" role="test" />
    <file md5sum="4f6890417983542f495994195135c5a3" name="tests/protection_password.phpt" role="test" />
+   <file md5sum="5fc933f1df5f99995c682912c544048d" name="tests/read_int_unparsable.phpt" role="test" />
+   <file md5sum="591f1062f1892a5d7e7e4f3e89319fea" name="tests/read_signed_and_zero.phpt" role="test" />
    <file md5sum="135d4939cae9a719eded94e263f628c5" name="tests/rich_string.phpt" role="test" />
+   <file md5sum="ccfca70d72a90774f1d4d00ef772d2f8" name="tests/rich_string_mixed_input.phpt" role="test" />
+   <file md5sum="a4bba59774dc682df47dff413fd4d98a" name="tests/set_background_image.phpt" role="test" />
+   <file md5sum="f1c887d3ab516ff9b3ee2d92bb7724c1" name="tests/set_header_footer.phpt" role="test" />
+   <file md5sum="b3411a966219210f87704ee75d6e5bb8" name="tests/set_properties.phpt" role="test" />
+   <file md5sum="d1baa2ce885eeef82af3cfdef44a1763" name="tests/set_row_reversed_range.phpt" role="test" />
    <file md5sum="e0f467091c3a5ca137cbbce362d54894" name="tests/sheet_add.phpt" role="test" />
    <file md5sum="4dd571eb75a5b8cc4deda72739c78d7c" name="tests/sheet_checkout.phpt" role="test" />
    <file md5sum="ed4ba69001223833746f68d7cf8c2730" name="tests/show_comment.phpt" role="test" />
    <file md5sum="5811dd930d7b0f916c662139ff1053d4" name="tests/string_from_column_index.phpt" role="test" />
+   <file md5sum="db300643e059cd40c6a91138dd0cd428" name="tests/tab_color.phpt" role="test" />
    <file md5sum="ecef7329cc0059a73b4f5db3631ec825" name="tests/timestamp_from_date_double.phpt" role="test" />
    <file md5sum="5d0d86ec5e7a8a4209dddd2a5edee166" name="tests/validation_limiting_input_to_a_value_in_a_dropdown_list.phpt" role="test" />
    <file md5sum="07d32cd6aa62b9798252df92af2c7f59" name="tests/validation_limiting_input_to_an_integer_greater_than_a_fixed_value.phpt" role="test" />
@@ -353,8 +402,14 @@
    <file md5sum="c51abb90279b8d925adb98e411dbac8c" name="tests/validation_limiting_input_to_an_integer_outside_a_fixed_range.phpt" role="test" />
    <file md5sum="5274206470470514ceac8b4f6c57e056" name="tests/validation_limiting_to_a_single_or_range_cell.phpt" role="test" />
    <file md5sum="e67001fe3b8092c3cca08570ee91b0c0" name="tests/validation_list_too_long.phpt" role="test" />
+   <file md5sum="2794814c1d8e84347196fa8b9f7ccbd4" name="tests/validation_reflection_dtor.phpt" role="test" />
    <file md5sum="379436234629d661ea18704b596ea5c5" name="tests/version.phpt" role="test" />
+   <file md5sum="d8e7bbce94e6be788c3240516df1c44a" name="tests/write_boolean.phpt" role="test" />
    <file md5sum="f0f017f73df0f0707bdc5647c51fdd70" name="tests/writer_exception.phpt" role="test" />
+   <file md5sum="38b117c46fa92b3b928689374b369072" name="tests/xlsx/hidden_row.xlsx" role="test" />
+   <file md5sum="dc0cf179203278167266ec16d62eff7f" name="tests/xlsx/phase1.xlsx" role="test" />
+   <file md5sum="c632d2b77bbd98f38a60694759a9685c" name="tests/xlsx/phase3.xlsx" role="test" />
+   <file md5sum="ae6c269e649834f28fe0fcbd82ae0d29" name="tests/xlsx/phase4.xlsx" role="test" />
    <file md5sum="a111d5404a8985d292bb80dc118836fa" name="tests/xlsx_to_csv.phpt" role="test" />
    <file md5sum="1a43e9736a9f387e309371c28f930583" name="tests/xlsx_to_csv_callback.phpt" role="test" />
    <file md5sum="8fddcc4da32a5db51b8a44020e9cbe8c" name="tests/xlsx_to_csv_callback_custom_delimiter.phpt" role="test" />
@@ -362,53 +417,12 @@
    <file md5sum="1528d060bb756f201d40ab2e488783fe" name="tests/xlsx_to_csv_skip_rows.phpt" role="test" />
    <file md5sum="69a7058bda1e143407e1fecedf110d14" name="tests/xlsx_to_csv_skip_rows_callback.phpt" role="test" />
    <file md5sum="097c215a199bce260b269e7ab4053f7f" name="tests/zoom.phpt" role="test" />
-   <file md5sum="1af8b7c3064d8e7b2ad50daf4b45c7f0" name="tests/include/skipif.inc" role="test" />
-   <file md5sum="8aa031a9f474460f06a933a83210a047" name="tests/insert_comment_opt.phpt" role="test" />
-   <file md5sum="fd7d985f58a4a2963b60810c9c2ef42a" name="tests/insert_image_buffer.phpt" role="test" />
-   <file md5sum="25858958701fa7a6f075fa580fc75abc" name="tests/insert_image_opt.phpt" role="test" />
-   <file md5sum="46e729b298af6c201a24c1ed4940e842" name="tests/open_xlsx_formula_verbose.phpt" role="test" />
-   <file md5sum="3353a285143a96db3ec45a241a8c915c" name="tests/open_xlsx_get_auto_filter.phpt" role="test" />
-   <file md5sum="395d0b0e7cb57dfecf5151832e9ab316" name="tests/open_xlsx_get_conditional_formats.phpt" role="test" />
-   <file md5sum="7c92d8e7ffcf052d9f88ac0b0cfd0fbf" name="tests/open_xlsx_get_data_validations.phpt" role="test" />
-   <file md5sum="dd41c30847bc06011dadb15cb899d664" name="tests/open_xlsx_get_defined_names.phpt" role="test" />
-   <file md5sum="704429045f207609b2e740174094fa60" name="tests/open_xlsx_get_hyperlinks.phpt" role="test" />
-   <file md5sum="8ddcb3ef485d7973436cd9d6a5148ad3" name="tests/open_xlsx_get_merged_cells.phpt" role="test" />
-   <file md5sum="221459194da3d455fcdca014a64ab9c4" name="tests/open_xlsx_get_page_setup.phpt" role="test" />
-   <file md5sum="c1fc164190124aac1f730e188e63e8a9" name="tests/open_xlsx_get_row_column_options.phpt" role="test" />
-   <file md5sum="b694667e2d5dcfe6c01a122b44f8ab22" name="tests/open_xlsx_get_sheet_protection.phpt" role="test" />
-   <file md5sum="d71bfcbc3f01f654a58aef35a9ee696a" name="tests/open_xlsx_get_style_format.phpt" role="test" />
-   <file md5sum="a15e3585f8cacd904177893b5f5c44f1" name="tests/open_xlsx_iterate_charts.phpt" role="test" />
-   <file md5sum="f046965eda05c0dfc8b58b1fc4c1fe3a" name="tests/open_xlsx_iterate_comments.phpt" role="test" />
-   <file md5sum="7d5e7becda0f6919384156b21c9af8da" name="tests/open_xlsx_iterate_images.phpt" role="test" />
-   <file md5sum="7f6d6674941436e3b619bfe804dd0f62" name="tests/open_xlsx_next_row_rich.phpt" role="test" />
-   <file md5sum="75ec45a64b95c50aa4dee75d6956bb4d" name="tests/insert_dynamic_formula.phpt" role="test" />
-   <file md5sum="51c2ebba742e4cbeb7c1731a0a053b75" name="tests/insert_dynamic_array_formula.phpt" role="test" />
-   <file md5sum="393e6a7b7ceb2d7afc08e25963b4d032" name="tests/open_xlsx_next_row_with_formula.phpt" role="test" />
-   <file md5sum="7df43a3db299df2e52e4305423223d58" name="tests/open_xlsx_next_row_with_formula_url.phpt" role="test" />
-   <file md5sum="2f6f92e91b110076731aa630d91cd203" name="tests/open_xlsx_sheet_visibility.phpt" role="test" />
-   <file md5sum="bd0bc58aa68b259e3a3096d2466d0ce5" name="tests/open_xlsx_skip_merged_follow.phpt" role="test" />
-   <file md5sum="54671b954c2f32dc5198b3b6c1292d4f" name="tests/open_xlsx_threaded_comments.phpt" role="test" />
-   <file md5sum="1985099f3c2f999cc475c52a4e7dfcca" name="tests/outline_level_column.phpt" role="test" />
-   <file md5sum="a074945aaa6bb0bc0a0849c3804178e7" name="tests/outline_level_column_const_memory.phpt" role="test" />
-   <file md5sum="b7ebda22760b5179729b5b9a57604934" name="tests/outline_level_row.phpt" role="test" />
-   <file md5sum="601ec609c974bb733a02e128551e99e1" name="tests/outline_level_row_const_memory.phpt" role="test" />
-   <file md5sum="b051fbde4a5777f8a46e2cdb2e2a4738" name="tests/outline_settings.phpt" role="test" />
-   <file md5sum="d8e7bbce94e6be788c3240516df1c44a" name="tests/write_boolean.phpt" role="test" />
-   <file md5sum="fb107b0089c2aa55fc305884813e8966" name="tests/page_setup.phpt" role="test" />
-   <file md5sum="22cb5ed6c568ab6287d520153c51250d" name="tests/set_background_image.phpt" role="test" />
-   <file md5sum="4022a6bdf63c220055bc4927834d0c66" name="tests/set_header_footer.phpt" role="test" />
-   <file md5sum="b3411a966219210f87704ee75d6e5bb8" name="tests/set_properties.phpt" role="test" />
-   <file md5sum="db300643e059cd40c6a91138dd0cd428" name="tests/tab_color.phpt" role="test" />
-   <file md5sum="38b117c46fa92b3b928689374b369072" name="tests/xlsx/hidden_row.xlsx" role="test" />
-   <file md5sum="dc0cf179203278167266ec16d62eff7f" name="tests/xlsx/phase1.xlsx" role="test" />
-   <file md5sum="c632d2b77bbd98f38a60694759a9685c" name="tests/xlsx/phase3.xlsx" role="test" />
-   <file md5sum="ae6c269e649834f28fe0fcbd82ae0d29" name="tests/xlsx/phase4.xlsx" role="test" />
    <file md5sum="bb4256831dfd81f951bd6f4afbe1719f" name="CREDITS" role="doc" />
-   <file md5sum="a629b83b2fe5157dd98b0f55fe753b50" name="README.md" role="doc" />
-   <file md5sum="1ca1303d561cdce910780e10402eaf25" name="README_zh.md" role="doc" />
+   <file md5sum="e508d664c32daa2366da914baaebf8d7" name="README.md" role="doc" />
+   <file md5sum="8ff9d8a7307f4b09d3aca2baf35c1e16" name="README_zh.md" role="doc" />
    <file md5sum="abc3c7def810a2a10036c268cb71cc94" name="LICENSE" role="doc" />
-   <file md5sum="1d99b579fb33ce2e5c394ecf7594f9d8" name="config.m4" role="src" />
-   <file md5sum="317601a6dc29f7a366519eda6f581e9a" name="config.w32" role="src" />
+   <file md5sum="fd8ecc02a543d7c2bcb87f435e12181d" name="config.m4" role="src" />
+   <file md5sum="5c8ef9e1fe1578395c7246da4a252d6c" name="config.w32" role="src" />
    <file md5sum="0ca27297a1f10800e75139dee4ff7e89" name="excel.php" role="src" />
    <file md5sum="ba1c714558e7afe17f001fa8c82bc3e2" name="php_xlswriter.h" role="src" />
    <file md5sum="ee25b061fa2eb80dabb24868666d69d3" name="xlswriter.c" role="src" />
@@ -427,6 +441,30 @@
  <providesextension>xlswriter</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2026-06-14</date>
+   <time>11:59:31</time>
+   <version>
+    <release>2.0.3</release>
+    <api>2.0.3</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="https://github.com/viest/php-ext-excel-export/blob/master/LICENSE">BSD license</license>
+   <notes>
+- Feature: autoSize(?string $range = null) sizes columns to fit their content. Column widths are estimated from the written cell values (wide/CJK code points count as two columns) and applied at output() time. Tracking is opt-in (call autoSize() before the writes it should size), so writes that never use it pay no per-cell cost; widths are clamped to Excel&apos;s 255 max (#305 / #514).
+- Performance: worksheet metadata (merges, hyperlinks, protection, row/col options) is now loaded lazily instead of eagerly at openSheet(), so data-only reads (getSheetData / nextRow / nextCellCallback / putCSV) skip the second full XML pass — about 40% faster on large sheets.
+- Performance: merge-follow lookups (SKIP_MERGED_FOLLOW) are indexed by last_row with a forward cursor, turning the per-cell scan from O(cells × merges) into amortised near-O(1).
+- Fix: RichString leaked one zend_string per instance (the constructor&apos;s zend_string_copy was never released) and its fetch-object offset pointed at the wrong struct; both corrected.
+- Fix: the cell/row-end/image/comment/chart callback bridges no longer zval_ptr_dtor an uninitialised return value when a callback throws or the call fails.
+- Fix: xlsx_to_csv leaked its temp row on the write-failure path; openFile() now resets reader bookkeeping the way openSheet() and the dtor do; fileName()/constMemory() handle workbook/worksheet allocation failure instead of dereferencing NULL.
+- Fix: the reader now reads every image from drawing.xml instead of stopping after the first 64 KB.
+- Fix: PHP 8.6 compatibility — XtOffsetOf replaced with the standard offsetof, and zval_dtor with zval_ptr_dtor_nogc.
+- Fix: setColumn()/setRow() leaked the per-call row/col options struct, and insertImage() leaked the path zend_string (#573).
+   </notes>
+  </release>
   <release>
    <date>2026-06-03</date>
    <time>00:00:00</time>

--- a/php_xlswriter.h
+++ b/php_xlswriter.h
@@ -18,7 +18,7 @@
 extern zend_module_entry xlswriter_module_entry;
 #define phpext_xlswriter_ptr &xlswriter_module_entry
 
-#define PHP_XLSWRITER_VERSION "2.0.3"
+#define PHP_XLSWRITER_VERSION "3.0.0"
 #define PHP_XLSWRITER_AUTHOR  "Jiexing.Wang (wjx@php.net)"
 
 extern int le_xls_writer;


### PR DESCRIPTION
Release preparation for **3.0.0** — no tag / GitHub Release / PECL upload is created by this PR; those remain manual steps after merge.

## Version
- `php_xlswriter.h`: `PHP_XLSWRITER_VERSION` → `3.0.0`
- `package.xml`: `<release>` / `<api>` → 3.0.0, `<date>` → 2026-07-05

## Release notes (`<notes>`)
Rewritten for 3.0.0, phrased in terms of the extension's user-facing capabilities:
- **Formula calculation** — `evaluateFormula()` evaluates an Excel formula (precedence/arithmetic, A1/A1:A3 references resolved against written cells, SUM/AVERAGE/MIN/MAX/COUNT/COUNTA, IF/CONCATENATE/UPPER/LEN, error values as strings); `computeFormula(true)` caches computed `<v>` results into the file.
- **Round-trip editing** of an existing workbook — `openFile()` then edit values / styles / merges / dates / dimensions, add worksheets, insert images and charts, and `output()`.
- **Performance** — normal-mode export ~27% faster, ~18% lower peak memory; constant_memory integer fast-path.
- **Fixes** — reader negative/zero-decimal read, locale-independent number write/parse, formula-engine DoS hardening, and memory-safety corrections.
- All existing methods, signatures and `Excel::*` / `Format::*` constant values are unchanged — upgrading requires no code changes.

The previous 2.0.3 notes were moved into `<changelog>` (PEAR convention: top-level `<notes>` is the current release, `<changelog>` holds history).

## `<contents>` manifest
- Recomputed every `md5sum` (71 were stale).
- Added the new shipped sources (`library/libxlsx/src/formula.c`, `library/libxlsx/include/libxlsx/formula.h`) and the new phpt tests.
- Removed five duplicate header entries that were present in the prior manifest.

## Validation
- `pecl package-validate`: **0 errors / 0 warnings**.
- Well-formed XML; extension builds and reports `3.0.0` at runtime.
- All **184 PHPT tests** pass.
