### PR TITLE
ci: trim PIE source package so install fits default memory_limit

### DIFF
--- a/.github/workflows/release-pie.yml
+++ b/.github/workflows/release-pie.yml
@@ -36,7 +36,29 @@ jobs:
           zipf="${GITHUB_WORKSPACE}/php_xlswriter-${tag}-src.zip"
 
           mkdir -p "${stage}"
-          rsync -a --exclude='.git' --exclude='.github' ./ "${stage}/"
+          # Ship only what is needed to build the extension. In particular the
+          # expat submodule carries ~82 MB of XML test data under
+          # library/libexpat/testdata; bundling it inflated the source archive
+          # to ~86 MB uncompressed, which exhausted PHP's default 128 MB
+          # memory_limit while Composer/PIE extracted the tarball on install
+          # (issue: `pie install viest/xlswriter` fatal in TarDownloader). Only
+          # library/libexpat/expat/lib is compiled (see config.m4), so drop the
+          # rest of expat plus our own dev-only trees.
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='library/libexpat/testdata' \
+            --exclude='library/libexpat/expat/tests' \
+            --exclude='library/libexpat/expat/examples' \
+            --exclude='library/libexpat/expat/fuzz' \
+            --exclude='library/libexpat/expat/xmlwf' \
+            --exclude='library/libexpat/expat/doc' \
+            --exclude='library/libxlsx/test' \
+            --exclude='bench' \
+            --exclude='backup' \
+            --exclude='examples' \
+            --exclude='resource' \
+            ./ "${stage}/"
 
           tar -C "${RUNNER_TEMP}" -czf "${tgz}" "xlswriter-${tag}"
           ( cd "${RUNNER_TEMP}" && zip -qr "${zipf}" "xlswriter-${tag}" )
@@ -45,6 +67,17 @@ jobs:
           # missing from the package.
           tar tzf "${tgz}" | grep -q "xlswriter-${tag}/config.m4"
           tar tzf "${tgz}" | grep -q "xlswriter-${tag}/library/libexpat/expat/lib/xmlparse.c"
+          # Guard against re-bloating the archive: the expat test data must not
+          # come back, and the compressed tarball should stay small.
+          if tar tzf "${tgz}" | grep -q "library/libexpat/testdata"; then
+            echo "error: expat testdata leaked back into the source package" >&2
+            exit 1
+          fi
+          size=$(stat -c%s "${tgz}")
+          if [ "${size}" -gt 5242880 ]; then
+            echo "error: source tarball is ${size} bytes (> 5 MiB); check for bundled bloat" >&2
+            exit 1
+          fi
 
       - name: Upload to release
         env:


### PR DESCRIPTION
## Problem

`pie install viest/xlswriter` (v3.0.0) aborts with a fatal error before building:

```
Fatal error: Allowed memory size of 134217728 bytes exhausted
  in .../Composer/Downloader/TarDownloader.php
```

## Root cause

The release source archive (`php_xlswriter-v3.0.0-src.tgz`) is **8.9 MB compressed / 85.9 MB uncompressed**. Of that, **83.5 MB is the expat submodule** — almost entirely `library/libexpat/testdata/largefiles/` (`ns_att_test.xml` 34.8 MB, `recset.xml` 29.6 MB, `wordnet_glossary` 14.8 MB, …). Composer/PIE loads the archive through `PharData` on install and exhausts PHP's default 128 MB `memory_limit`.

Only `library/libexpat/expat/lib` is actually compiled (see `config.m4`); the test data, expat's own tests/examples/docs, and our dev-only trees are never needed to build.

## Fix

Exclude the non-build content from the release `rsync`:
- `library/libexpat/{testdata,expat/tests,expat/examples,expat/fuzz,expat/xmlwf,expat/doc}`
- `library/libxlsx/test`, `bench`, `backup`, `examples`, `resource`

Result: **~0.8 MB compressed / ~3.8 MB uncompressed**. Added guards that fail the job if the expat test data reappears or the tarball exceeds 5 MiB.

## Verification (php:8.3-cli container)

- Old 85.9 MB tarball → `pie install` fatals on the default 128 MB limit.
- Trimmed 3.8 MB tarball → extracts under 128 MB, and `phpize && ./configure && make` builds a loadable `.so` reporting `version=3.0.0`.

## Follow-up

This fixes future releases. The already-published **v3.0.0 assets are being replaced in place** with the trimmed archives so existing `pie install` works without waiting for a new tag.
