### PR TITLE
docs: document PECL and PIE install methods and their build prerequis…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ xlswriter is a PHP C Extension for Excel 2007+ XLSX files. It writes text, numbe
 
 ###### Unix
 
-xlswriter requires the zlib development headers at build time. Install them
-first if they are missing (common on minimal images):
+Both install methods below build from source, so the zlib development headers
+must be present first (they are often missing on minimal images):
 
 ```bash
 # Debian / Ubuntu
@@ -84,8 +84,23 @@ apk add zlib-dev
 yum install -y zlib-devel
 ```
 
+Then install with either **PECL** or **PIE**:
+
+**PECL**
+
 ```bash
 pecl install xlswriter
+```
+
+**PIE**
+
+[PIE](https://github.com/php/pie) also builds from source and additionally needs
+the autotools build chain (autoconf, make, a compiler and **libtool**). It can
+install those missing build tools for you with `--auto-install-build-tools`, but
+it cannot install zlib — make sure the headers above are in place first:
+
+```bash
+pie install --auto-install-build-tools viest/xlswriter
 ```
 
 ###### Windows

--- a/README_zh.md
+++ b/README_zh.md
@@ -70,6 +70,44 @@ xlswriter 是一个 PHP C 扩展，用于处理 Excel 2007+ XLSX 文件：向新
 * 读取图片、图表与批注
 * 读取公式及其缓存值
 
+#### 安装
+
+###### Unix
+
+下面两种安装方式都是从源码编译，因此需要先装好 zlib 开发头文件（最小镜像通常缺失）：
+
+```bash
+# Debian / Ubuntu
+apt-get install -y zlib1g-dev
+# Alpine
+apk add zlib-dev
+# RHEL / CentOS / Fedora
+yum install -y zlib-devel
+```
+
+然后用 **PECL** 或 **PIE** 任选其一安装：
+
+**PECL**
+
+```bash
+pecl install xlswriter
+```
+
+**PIE**
+
+[PIE](https://github.com/php/pie) 同样从源码编译，除上面的 zlib 开发头文件外，还需要
+autotools 构建链（autoconf、make、编译器以及 **libtool**）。PIE 可以用
+`--auto-install-build-tools` 自动安装缺失的构建工具，但无法安装 zlib——请先确保上面的
+头文件已就位：
+
+```bash
+pie install --auto-install-build-tools viest/xlswriter
+```
+
+###### Windows
+
+[下载 dll](https://github.com/viest/php-ext-xlswriter/releases)
+
 #### 基准测试
 
 测试环境: Macbook Pro 13 inch, Intel Core i5, 16GB 2133MHz LPDDR3 Memory, 128GB SSD Storage.


### PR DESCRIPTION
…ites

Restructure the Unix install section so PECL and PIE are two sibling build-from-source methods under a shared zlib-headers prerequisite, instead of PECL being buried under "Unix" and PIE sitting as a peer of the platform.

Add the PIE method (`pie install --auto-install-build-tools viest/xlswriter`) and note the extra autotools/libtool build chain it needs, plus that PIE cannot auto-install zlib. Mirror the whole section into README_zh.md, which had no install-command section before.