### PR TITLE
fix: bug and hot-path fixes from full-code review

### DIFF
--- a/kernel/excel.c
+++ b/kernel/excel.c
@@ -821,6 +821,11 @@ PHP_METHOD(vtiful_xls, constMemory)
 
     GET_CONFIG_PATH(dir_path, vtiful_xls_ce, PROP_OBJ(return_value));
 
+    if(directory_exists(ZSTR_VAL(Z_STR_P(dir_path))) == XLSWRITER_FALSE) {
+        zend_throw_exception(vtiful_exception_ce, "Configure 'path' directory does not exist", 121);
+        return;
+    }
+
     xls_object *obj = Z_XLS_P(getThis());
 
     if(obj->write_ptr.workbook == NULL) {
@@ -959,6 +964,10 @@ PHP_METHOD(vtiful_xls, data)
 
     WORKBOOK_NOT_INITIALIZED(obj);
 
+    // With no per-cell number format the lookup is loop-invariant and free of
+    // side effects, so resolve it once instead of per cell.
+    lxlsx_format *cell_format = object_format(obj, NULL, obj->lxlsx_format_ptr.format);
+
     ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(data), data_r_value)
         if (Z_TYPE_P(data_r_value) == IS_REFERENCE) {
             data_r_value = Z_REFVAL_P(data_r_value);
@@ -981,7 +990,7 @@ PHP_METHOD(vtiful_xls, data)
                 column_index = index;
             }
             type_writer(data, SHEET_CURRENT_LINE(obj), column_index, &obj->write_ptr, NULL,
-                        object_format(obj, NULL, obj->lxlsx_format_ptr.format));
+                        cell_format);
 
             // next number index
             ++column_index;

--- a/kernel/validation.c
+++ b/kernel/validation.c
@@ -564,6 +564,8 @@ PHP_METHOD(vtiful_validation, valueDatetime)
         RETURN_NULL();
     }
 
+    ZVAL_COPY(return_value, getThis());
+
     obj->ptr.validation->value_datetime = timestamp_to_datetime(timestamp);
 }
 /* }}} */
@@ -631,6 +633,8 @@ PHP_METHOD(vtiful_validation, minimumDatetime)
         RETURN_NULL();
     }
 
+    ZVAL_COPY(return_value, getThis());
+
     obj->ptr.validation->minimum_datetime = timestamp_to_datetime(timestamp);
 }
 /* }}} */
@@ -697,6 +701,8 @@ PHP_METHOD(vtiful_validation, maximumDatetime)
     if (obj->ptr.validation == NULL) {
         RETURN_NULL();
     }
+
+    ZVAL_COPY(return_value, getThis());
 
     obj->ptr.validation->maximum_datetime = timestamp_to_datetime(timestamp);
 }

--- a/library/libxlsx/include/libxlsx/shared_strings.h
+++ b/library/libxlsx/include/libxlsx/shared_strings.h
@@ -37,12 +37,15 @@ STAILQ_HEAD(lxlsx_sst_order_list, lxlsx_sst_element);
  * in a separate list.
  */
 struct lxlsx_sst_element {
-    uint32_t index;
+    /* Pointer-aligned members first: with the scalars leading, LP64 padding
+     * inflated this per-unique-string node from 56 to 64 bytes. */
     char *string;
-    uint8_t is_rich_string;
 
     STAILQ_ENTRY (lxlsx_sst_element) lxlsx_sst_order_pointers;
     RB_ENTRY (lxlsx_sst_element) lxlsx_sst_tree_pointers;
+
+    uint32_t index;
+    uint8_t is_rich_string;
 };
 
 /*

--- a/library/libxlsx/include/libxlsx/worksheet.h
+++ b/library/libxlsx/include/libxlsx/worksheet.h
@@ -2165,6 +2165,12 @@ typedef struct lxlsx_worksheet {
     uint8_t optimize;
     struct lxlsx_row *optimize_row;
 
+    /* constant_memory cell recycling: cells live for exactly one row before
+     * the flush loop discards them, so released structs are chained through
+     * their (payload-free) data union instead of a free()/calloc() round
+     * trip per cell. Normal mode never pushes here. */
+    struct lxlsx_cell *cell_pool;
+
     uint16_t fit_height;
     uint16_t fit_width;
     uint16_t horizontal_dpi;

--- a/library/libxlsx/include/libxlsx/xmlwriter.h
+++ b/library/libxlsx/include/libxlsx/xmlwriter.h
@@ -184,6 +184,8 @@ void lxlsx_xml_data_element(FILE *xmlfile,
 
 void lxlsx_xml_rich_si_element(FILE *xmlfile, const char *string);
 
+void lxlsx_xml_write_t_element(FILE *xmlfile, const char *string);
+
 uint8_t lxlsx_has_control_characters(const char *string);
 char *lxlsx_escape_control_characters(const char *string);
 char *lxlsx_escape_url_characters(const char *string, uint8_t escape_hash);

--- a/library/libxlsx/internal/platform.h
+++ b/library/libxlsx/internal/platform.h
@@ -36,4 +36,14 @@
 #  define lxlsx_reader_lseek(fd, off, whence)  lseek((fd), (off), (whence))
 #endif
 
+/* 64-bit ftell: plain ftell() returns long, which is 32-bit on Windows and
+ * ILP32 targets and caps whole-file sizes / ZIP offsets at 2GB. Writer and
+ * edit paths use this for file-size and offset queries. */
+#include <stdio.h>
+#if defined(_MSC_VER)
+#  define lxlsx_ftello(fp) _ftelli64(fp)
+#else
+#  define lxlsx_ftello(fp) ftello(fp)
+#endif
+
 #endif

--- a/library/libxlsx/internal/xlsx_private.h
+++ b/library/libxlsx/internal/xlsx_private.h
@@ -267,7 +267,6 @@ struct lxlsx_reader_worksheet {
 
     /* Cell being assembled */
     char          cell_t[16];
-    char          cell_ref[32];
     uint32_t      cell_style_id;
     size_t        cell_row;
     size_t        cell_col;

--- a/library/libxlsx/src/packager.c
+++ b/library/libxlsx/src/packager.c
@@ -49,6 +49,7 @@
 #include "libxlsx/packager.h"
 #include "libxlsx/hash_table.h"
 #include "libxlsx/utility.h"
+#include "platform.h"
 
 /*
  * Deflate level for zip members. zlib's default (6) enables lazy match
@@ -144,30 +145,33 @@ _fclose_memstream(voidpf opaque, voidpf stream)
 {
     lxlsx_packager *packager = (lxlsx_packager *) opaque;
     FILE *file = (FILE *) stream;
-    long size;
+    lxlsx_reader_off_t size;
 
     /* Ensure memstream buffer is updated */
     if (fflush(file))
         goto mem_error;
 
     /* If the memstream is backed by a temporary file, no buffer is created,
-       so create it manually. */
+       so create it manually. Mirrors lxlsx_capture_filehandle(): 64-bit size
+       query (plain ftell caps at 2GB where long is 32-bit), zero-length-safe
+       malloc and fread. */
     if (!packager->output_buffer) {
         if (fseek(file, 0L, SEEK_END))
             goto mem_error;
 
-        size = ftell(file);
-        if (size == -1)
+        size = lxlsx_ftello(file);
+        if (size < 0 || (unsigned long long) size >= (unsigned long long) (size_t) -1)
             goto mem_error;
 
-        packager->output_buffer = malloc(size);
+        packager->output_buffer = malloc((size_t) size + 1);
         GOTO_LABEL_ON_MEM_ERROR(packager->output_buffer, mem_error);
 
         rewind(file);
-        if (fread((void *) packager->output_buffer, size, 1, file) < 1)
+        if (size > 0
+            && fread((void *) packager->output_buffer, (size_t) size, 1, file) < 1)
             goto mem_error;
 
-        packager->output_buffer_size = size;
+        packager->output_buffer_size = (size_t) size;
     }
 
     return fclose(file);

--- a/library/libxlsx/src/shared_strings.c
+++ b/library/libxlsx/src/shared_strings.c
@@ -111,27 +111,6 @@ _element_cmp(struct lxlsx_sst_element *element1, struct lxlsx_sst_element *eleme
 LXLSX_DEFINE_XML_DECLARATION(_sst_xml_declaration, lxlsx_sst)
 
 /*
- * Write the <t> element.
- */
-STATIC void
-_write_t(lxlsx_sst *self, char *string)
-{
-    struct lxlsx_xml_attribute_list attributes;
-    struct lxlsx_xml_attribute *attribute;
-
-    LXLSX_INIT_ATTRIBUTES();
-
-    /* Add attribute to preserve leading or trailing whitespace. */
-    if (isspace((unsigned char) string[0])
-        || isspace((unsigned char) string[strlen(string) - 1]))
-        LXLSX_PUSH_ATTRIBUTES_STR("xml:space", "preserve");
-
-    lxlsx_xml_data_element(self->file, "t", string, &attributes);
-
-    LXLSX_FREE_ATTRIBUTES();
-}
-
-/*
  * Write the <si> element.
  */
 STATIC void
@@ -148,7 +127,7 @@ _write_si(lxlsx_sst *self, char *string)
     }
 
     /* Write the t element. */
-    _write_t(self, string);
+    lxlsx_xml_write_t_element(self->file, string);
 
     lxlsx_xml_end_tag(self->file, "si");
 

--- a/library/libxlsx/src/source_package.c
+++ b/library/libxlsx/src/source_package.c
@@ -12,6 +12,7 @@
 #include <zlib.h>
 
 #include "libxlsx/source_package.h"
+#include "platform.h"
 
 #define ZIP_LOCAL_FILE_SIG   0x04034b50u
 #define ZIP_CENTRAL_FILE_SIG 0x02014b50u
@@ -134,10 +135,16 @@ static lxlsx_error write_le32(FILE *fp, uint32_t v)
 
 static lxlsx_error current_offset(FILE *fp, uint32_t *out)
 {
-    long pos = ftell(fp);
+    /* 64-bit query where the platform supports it (lxlsx_ftello maps to
+     * _ftelli64 on MSVC; ftello elsewhere, which stays 32-bit where off_t is
+     * 32-bit, e.g. MinGW/ILP32). The 4GB ZIP64 guard is compared in a fixed
+     * 64-bit unsigned domain: pos is non-negative here, and casting the
+     * threshold to lxlsx_reader_off_t would truncate to -1 (making the guard
+     * fire for every offset) when that type is a 32-bit signed off_t. */
+    lxlsx_reader_off_t pos = lxlsx_ftello(fp);
     if (pos < 0)
         return LXLSX_ERROR_ZIP_FILE_OPERATION;
-    if ((unsigned long)pos > 0xffffffffUL)
+    if ((uint64_t) pos > 0xffffffffULL)
         return LXLSX_ERROR_FEATURE_NOT_SUPPORTED;
     *out = (uint32_t)pos;
     return LXLSX_NO_ERROR;
@@ -401,7 +408,7 @@ static lxlsx_error parse_package(lxlsx_source_package *package)
 static lxlsx_error slurp_file(const char *path, unsigned char **out, size_t *out_len)
 {
     FILE *fp;
-    long size;
+    lxlsx_reader_off_t size;
     unsigned char *buf;
     size_t got;
 
@@ -416,10 +423,17 @@ static lxlsx_error slurp_file(const char *path, unsigned char **out, size_t *out
         fclose(fp);
         return LXLSX_ERROR_ZIP_FILE_OPERATION;
     }
-    size = ftell(fp);
+    /* 64-bit size query: plain ftell caps the openable file size at 2GB
+     * where long is 32-bit (Windows, ILP32). */
+    size = lxlsx_ftello(fp);
     if (size < 0) {
         fclose(fp);
         return LXLSX_ERROR_ZIP_FILE_OPERATION;
+    }
+    if ((unsigned long long) size > (unsigned long long) (size_t) -1) {
+        /* Larger than this target's address space can hold. */
+        fclose(fp);
+        return LXLSX_ERROR_FEATURE_NOT_SUPPORTED;
     }
     if (fseek(fp, 0, SEEK_SET) != 0) {
         fclose(fp);

--- a/library/libxlsx/src/styles.c
+++ b/library/libxlsx/src/styles.c
@@ -88,19 +88,7 @@ lxlsx_styles_free(lxlsx_styles *styles)
 void
 lxlsx_styles_write_string_fragment(lxlsx_styles *self, const char *string)
 {
-    struct lxlsx_xml_attribute_list attributes;
-    struct lxlsx_xml_attribute *attribute;
-
-    LXLSX_INIT_ATTRIBUTES();
-
-    /* Add attribute to preserve leading or trailing whitespace. */
-    if (isspace((unsigned char) string[0])
-        || isspace((unsigned char) string[strlen(string) - 1]))
-        LXLSX_PUSH_ATTRIBUTES_STR("xml:space", "preserve");
-
-    lxlsx_xml_data_element(self->file, "t", string, &attributes);
-
-    LXLSX_FREE_ATTRIBUTES();
+    lxlsx_xml_write_t_element(self->file, string);
 }
 
 void

--- a/library/libxlsx/src/utility.c
+++ b/library/libxlsx/src/utility.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include "libxlsx.h"
 #include "libxlsx/common.h"
+#include "platform.h"
 #include "libxlsx/third_party/tmpfileplus.h"
 
 #define LXLSX_TMPFILE_BUFFER_SIZE (64 * 1024)
@@ -723,11 +724,15 @@ lxlsx_capture_filehandle(FILE *fh, char *buffer, size_t buffer_size,
         *out_len = buffer_size;
     }
     else {
-        /* tmpfile backend: read the contents back. */
-        long size;
+        /* tmpfile backend: read the contents back. 64-bit size query: plain
+         * ftell caps at 2GB where long is 32-bit (Windows, ILP32). */
+        lxlsx_reader_off_t size;
         if (fseek(fh, 0L, SEEK_END)) { err = LXLSX_ERROR_CREATING_TMPFILE; goto done; }
-        size = ftell(fh);
-        if (size < 0) { err = LXLSX_ERROR_CREATING_TMPFILE; goto done; }
+        size = lxlsx_ftello(fh);
+        if (size < 0 || (unsigned long long) size >= (unsigned long long) (size_t) -1) {
+            err = LXLSX_ERROR_CREATING_TMPFILE;
+            goto done;
+        }
         *out = malloc((size_t) size + 1);
         if (!*out) { err = LXLSX_ERROR_MEMORY_MALLOC_FAILED; goto done; }
         rewind(fh);

--- a/library/libxlsx/src/workbook.c
+++ b/library/libxlsx/src/workbook.c
@@ -2154,6 +2154,13 @@ lxlsx_workbook_add_worksheet(lxlsx_workbook *self, const char *sheetname)
     lxlsx_worksheet_name = calloc(1, sizeof(struct lxlsx_worksheet_name));
     GOTO_LABEL_ON_MEM_ERROR(lxlsx_worksheet_name, mem_error);
 
+    /* Allocate the sheet wrapper before the worksheet is created: once the
+     * worksheet is linked into self->worksheets below there is no failure
+     * path left, so mem_error can never see (and shallow-free) a node that
+     * is already reachable from the workbook lists. */
+    sheet = calloc(1, sizeof(lxlsx_sheet));
+    GOTO_LABEL_ON_MEM_ERROR(sheet, mem_error);
+
     /* Initialize the metadata to pass to the worksheet. */
     init_data.hidden = 0;
     init_data.index = self->num_sheets;
@@ -2178,12 +2185,8 @@ lxlsx_workbook_add_worksheet(lxlsx_workbook *self, const char *sheetname)
     self->num_worksheets++;
     STAILQ_INSERT_TAIL(self->worksheets, worksheet, list_pointers);
 
-    /* Create a new sheet object. */
-    sheet = calloc(1, sizeof(lxlsx_sheet));
-    GOTO_LABEL_ON_MEM_ERROR(sheet, mem_error);
+    /* Add it to the sheet list. */
     sheet->u.worksheet = worksheet;
-
-    /* Add it to the worksheet list. */
     self->num_sheets++;
     STAILQ_INSERT_TAIL(self->sheets, sheet, list_pointers);
 
@@ -2195,10 +2198,12 @@ lxlsx_workbook_add_worksheet(lxlsx_workbook *self, const char *sheetname)
     return worksheet;
 
 mem_error:
+    /* Only reachable before the worksheet exists: lxlsx_worksheet_new frees
+     * its own partial state (without taking init_data ownership) on failure. */
     free((void *) init_data.name);
     free((void *) init_data.quoted_name);
     free(lxlsx_worksheet_name);
-    free(worksheet);
+    free(sheet);
     return NULL;
 }
 
@@ -2245,6 +2250,13 @@ lxlsx_workbook_add_chartsheet(lxlsx_workbook *self, const char *sheetname)
     lxlsx_chartsheet_name = calloc(1, sizeof(struct lxlsx_chartsheet_name));
     GOTO_LABEL_ON_MEM_ERROR(lxlsx_chartsheet_name, mem_error);
 
+    /* Allocate the sheet wrapper before the chartsheet is created: once the
+     * chartsheet is linked into self->chartsheets below there is no failure
+     * path left, so mem_error can never see (and shallow-free) a node that
+     * is already reachable from the workbook lists. */
+    sheet = calloc(1, sizeof(lxlsx_sheet));
+    GOTO_LABEL_ON_MEM_ERROR(sheet, mem_error);
+
     /* Initialize the metadata to pass to the chartsheet. */
     init_data.hidden = 0;
     init_data.index = self->num_sheets;
@@ -2262,13 +2274,9 @@ lxlsx_workbook_add_chartsheet(lxlsx_workbook *self, const char *sheetname)
     self->num_chartsheets++;
     STAILQ_INSERT_TAIL(self->chartsheets, chartsheet, list_pointers);
 
-    /* Create a new sheet object. */
-    sheet = calloc(1, sizeof(lxlsx_sheet));
-    GOTO_LABEL_ON_MEM_ERROR(sheet, mem_error);
+    /* Add it to the sheet list. */
     sheet->is_chartsheet = LXLSX_TRUE;
     sheet->u.chartsheet = chartsheet;
-
-    /* Add it to the chartsheet list. */
     self->num_sheets++;
     STAILQ_INSERT_TAIL(self->sheets, sheet, list_pointers);
 
@@ -2280,10 +2288,13 @@ lxlsx_workbook_add_chartsheet(lxlsx_workbook *self, const char *sheetname)
     return chartsheet;
 
 mem_error:
+    /* Only reachable before the chartsheet exists: lxlsx_chartsheet_new
+     * frees its own partial state (without taking init_data ownership) on
+     * failure. */
     free((void *) init_data.name);
     free((void *) init_data.quoted_name);
     free(lxlsx_chartsheet_name);
-    free(chartsheet);
+    free(sheet);
     return NULL;
 }
 

--- a/library/libxlsx/src/worksheet.c
+++ b/library/libxlsx/src/worksheet.c
@@ -377,14 +377,11 @@ _free_filter_rules(lxlsx_worksheet *worksheet)
 }
 
 /*
- * Free a worksheet cell.
+ * Free a worksheet cell's owned payload, keeping the struct itself.
  */
 STATIC void
-_free_cell(lxlsx_cell *cell)
+_free_cell_payload(lxlsx_cell *cell)
 {
-    if (!cell)
-        return;
-
     switch (cell->type) {
     case INLINE_STRING_CELL:
     case INLINE_RICH_STRING_CELL:
@@ -415,8 +412,54 @@ _free_cell(lxlsx_cell *cell)
     default:
         break;
     }
+}
 
+/*
+ * Free a worksheet cell.
+ */
+STATIC void
+_free_cell(lxlsx_cell *cell)
+{
+    if (!cell)
+        return;
+
+    _free_cell_payload(cell);
     free(cell);
+}
+
+/*
+ * Allocate a zeroed cell, reusing a recycled struct from the worksheet's
+ * constant_memory pool when one is available. Normal mode never recycles,
+ * so the pool stays empty and this is a plain calloc.
+ */
+STATIC lxlsx_cell *
+_cell_calloc(lxlsx_worksheet *self)
+{
+    lxlsx_cell *cell = self ? self->cell_pool : NULL;
+
+    if (cell) {
+        memcpy(&self->cell_pool, &cell->data, sizeof(lxlsx_cell *));
+        memset(cell, 0, sizeof(*cell));
+        return cell;
+    }
+
+    return calloc(1, sizeof(lxlsx_cell));
+}
+
+/*
+ * Release a cell in constant_memory mode: free the owned payload and chain
+ * the struct into the pool through its now-unused data union, avoiding the
+ * per-cell free()/calloc() round trip of the row flush loop.
+ */
+STATIC void
+_recycle_cell(lxlsx_worksheet *self, lxlsx_cell *cell)
+{
+    if (!cell)
+        return;
+
+    _free_cell_payload(cell);
+    memcpy(&cell->data, &self->cell_pool, sizeof(lxlsx_cell *));
+    self->cell_pool = cell;
 }
 
 /*
@@ -829,6 +872,15 @@ lxlsx_worksheet_free(lxlsx_worksheet *worksheet)
         free(worksheet->array);
     }
 
+    /* Drain the constant_memory cell pool: recycled structs own no payload
+     * and are chained through their data union. */
+    while (worksheet->cell_pool) {
+        lxlsx_cell *pool_next;
+        memcpy(&pool_next, &worksheet->cell_pool->data, sizeof(pool_next));
+        free(worksheet->cell_pool);
+        worksheet->cell_pool = pool_next;
+    }
+
     if (worksheet->optimize_row)
         free(worksheet->optimize_row);
 
@@ -896,10 +948,10 @@ _new_row(lxlsx_row_t row_num)
  * Create a new worksheet number cell object.
  */
 STATIC lxlsx_cell *
-_new_number_cell(lxlsx_row_t row_num,
+_new_number_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
                  lxlsx_col_t col_num, double value, lxlsx_format *format)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->row_num = row_num;
@@ -915,11 +967,11 @@ _new_number_cell(lxlsx_row_t row_num,
  * Create a new worksheet string cell object.
  */
 STATIC lxlsx_cell *
-_new_string_cell(lxlsx_row_t row_num,
+_new_string_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
                  lxlsx_col_t col_num, int32_t string_id, char *lxlsx_sst_string,
                  lxlsx_format *format)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->row_num = row_num;
@@ -936,10 +988,10 @@ _new_string_cell(lxlsx_row_t row_num,
  * Create a new worksheet inline_string cell object.
  */
 STATIC lxlsx_cell *
-_new_inline_string_cell(lxlsx_row_t row_num,
+_new_inline_string_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
                         lxlsx_col_t col_num, char *string, lxlsx_format *format)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->row_num = row_num;
@@ -955,11 +1007,11 @@ _new_inline_string_cell(lxlsx_row_t row_num,
  * Create a new worksheet inline_string cell object for rich strings.
  */
 STATIC lxlsx_cell *
-_new_inline_rich_string_cell(lxlsx_row_t row_num,
+_new_inline_rich_string_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
                              lxlsx_col_t col_num, const char *string,
                              lxlsx_format *format)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->row_num = row_num;
@@ -975,10 +1027,10 @@ _new_inline_rich_string_cell(lxlsx_row_t row_num,
  * Create a new worksheet formula cell object.
  */
 STATIC lxlsx_cell *
-_new_formula_cell(lxlsx_row_t row_num,
+_new_formula_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
                   lxlsx_col_t col_num, char *formula, lxlsx_format *format)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->data.writer.value.formula =
@@ -1001,10 +1053,11 @@ _new_formula_cell(lxlsx_row_t row_num,
  * Create a new worksheet array formula cell object.
  */
 STATIC lxlsx_cell *
-_new_array_formula_cell(lxlsx_row_t row_num, lxlsx_col_t col_num, char *formula,
+_new_array_formula_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
+                        lxlsx_col_t col_num, char *formula,
                         char *range, lxlsx_format *format, uint8_t is_dynamic)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->data.writer.value.formula =
@@ -1032,9 +1085,10 @@ _new_array_formula_cell(lxlsx_row_t row_num, lxlsx_col_t col_num, char *formula,
  * Create a new worksheet blank cell object.
  */
 STATIC lxlsx_cell *
-_new_blank_cell(lxlsx_row_t row_num, lxlsx_col_t col_num, lxlsx_format *format)
+_new_blank_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
+                lxlsx_col_t col_num, lxlsx_format *format)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->row_num = row_num;
@@ -1049,10 +1103,11 @@ _new_blank_cell(lxlsx_row_t row_num, lxlsx_col_t col_num, lxlsx_format *format)
  * Create a new worksheet boolean cell object.
  */
 STATIC lxlsx_cell *
-_new_boolean_cell(lxlsx_row_t row_num, lxlsx_col_t col_num, int value,
+_new_boolean_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
+                  lxlsx_col_t col_num, int value,
                   lxlsx_format *format)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->row_num = row_num;
@@ -1068,10 +1123,11 @@ _new_boolean_cell(lxlsx_row_t row_num, lxlsx_col_t col_num, int value,
  * Create a new worksheet error cell object.
  */
 STATIC lxlsx_cell *
-_new_error_cell(lxlsx_row_t row_num, lxlsx_col_t col_num, uint32_t value,
+_new_error_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
+                lxlsx_col_t col_num, uint32_t value,
                 lxlsx_format *format)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->row_num = row_num;
@@ -1087,10 +1143,11 @@ _new_error_cell(lxlsx_row_t row_num, lxlsx_col_t col_num, uint32_t value,
  * Create a new comment cell object.
  */
 STATIC lxlsx_cell *
-_new_comment_cell(lxlsx_row_t row_num, lxlsx_col_t col_num,
+_new_comment_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
+                  lxlsx_col_t col_num,
                   lxlsx_vml_obj *comment_obj)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->row_num = row_num;
@@ -1105,11 +1162,12 @@ _new_comment_cell(lxlsx_row_t row_num, lxlsx_col_t col_num,
  * Create a new worksheet hyperlink cell object.
  */
 STATIC lxlsx_cell *
-_new_hyperlink_cell(lxlsx_row_t row_num, lxlsx_col_t col_num,
+_new_hyperlink_cell(lxlsx_worksheet *self, lxlsx_row_t row_num,
+                    lxlsx_col_t col_num,
                     enum cell_types link_type, char *url, char *string,
                     char *tooltip)
 {
-    lxlsx_cell *cell = calloc(1, sizeof(lxlsx_cell));
+    lxlsx_cell *cell = _cell_calloc(self);
     RETURN_ON_MEM_ERROR(cell, cell);
 
     cell->data.writer.value.hyperlink =
@@ -1232,7 +1290,7 @@ _insert_cell(lxlsx_worksheet *self, lxlsx_row_t row_num, lxlsx_col_t col_num,
 
             /* Overwrite an existing cell if necessary. */
             if (self->array[col_num])
-                _free_cell(self->array[col_num]);
+                _recycle_cell(self, self->array[col_num]);
 
             self->array[col_num] = cell;
         }
@@ -1256,7 +1314,7 @@ _insert_cell_placeholder(lxlsx_worksheet *self, lxlsx_row_t row_num,
     if (self->optimize)
         return;
 
-    cell = _new_blank_cell(row_num, col_num, NULL);
+    cell = _new_blank_cell(self, row_num, col_num, NULL);
     if (!cell)
         return;
 
@@ -4496,6 +4554,15 @@ _obuf_write(lxlsx_worksheet *self, const char *s, size_t n)
     self->obuf_len += n;
 }
 
+/* lxlsx_xml_escape_data_write() adapter: stream escaped chunks straight into
+ * the output buffer, so inline strings need no intermediate heap copy. */
+STATIC int
+_obuf_escape_cb(void *userdata, const char *data, size_t len)
+{
+    _obuf_write((lxlsx_worksheet *) userdata, data, len);
+    return 0;
+}
+
 /* Write an unsigned 32-bit value as decimal at `p`, return the digit count. */
 static inline int
 _u32_dec(char *p, uint32_t v)
@@ -4596,107 +4663,78 @@ _cell_ref_prefix(char *p, lxlsx_row_t row_num, lxlsx_col_t col_num,
 
 /*
  * Write out a number worksheet cell. Doesn't use the xml functions as an
- * optimization in the inner cell writing loop.
+ * optimization in the inner cell writing loop: the whole <c> element is
+ * assembled with the hand-rolled formatters and emitted with one write in
+ * both constant_memory (stream buffer) and normal (FILE) mode, skipping the
+ * per-cell fprintf format parsing and the snprintf-backed range string.
  */
 STATIC void
-_write_number_cell(lxlsx_worksheet *self, char *range,
-                   int32_t style_index, lxlsx_cell *cell)
+_write_number_cell(lxlsx_worksheet *self, int32_t style_index,
+                   lxlsx_cell *cell)
 {
-    /* constant_memory fast path: assemble straight into the stream buffer. */
-    if (self->optimize) {
-        char buf[64 + LXLSX_ATTR_32];
-        double value = cell->data.writer.value.number;
-        int n = _cell_ref_prefix(buf, cell->row_num, cell->col_num,
-                                 style_index);
-        buf[n++] = '>';
-        buf[n++] = '<';
-        buf[n++] = 'v';
-        buf[n++] = '>';
+    char buf[64 + LXLSX_ATTR_32];
+    double value = cell->data.writer.value.number;
+    int n = _cell_ref_prefix(buf, cell->row_num, cell->col_num, style_index);
 
-        /* Integer fast path: most bulk numeric data is integral, and the
-         * general double formatter (emyg_dtoa) dominates the write profile.
-         * An integral value in safe int64 range formats byte-identically via
-         * a plain itoa, skipping the float algorithm entirely. The bound stays
-         * inside INT64_MAX/MIN so the cast and negation below are well-defined. */
-        if (value >= -9.2e18 && value <= 9.2e18
-            && value == (double) (int64_t) value) {
-            n += _i64_dec(buf + n, (int64_t) value);
-        }
-        else {
-            char num[LXLSX_ATTR_32];
+    buf[n++] = '>';
+    buf[n++] = '<';
+    buf[n++] = 'v';
+    buf[n++] = '>';
+
+    /* Integer fast path: most bulk numeric data is integral, and the
+     * general double formatter (emyg_dtoa) dominates the write profile.
+     * An integral value in safe int64 range formats byte-identically via
+     * a plain itoa, skipping the float algorithm entirely. The bound stays
+     * inside INT64_MAX/MIN so the cast and negation below are well-defined. */
+    if (value >= -9.2e18 && value <= 9.2e18
+        && value == (double) (int64_t) value) {
+        n += _i64_dec(buf + n, (int64_t) value);
+    }
+    else {
+        char num[LXLSX_ATTR_32];
 #ifdef USE_DTOA_LIBRARY
-            lxlsx_sprintf_dbl(num, value);
+        lxlsx_sprintf_dbl(num, value);
 #else
-            lxlsx_snprintf(num, LXLSX_ATTR_32, "%.16G", value);
+        lxlsx_snprintf(num, LXLSX_ATTR_32, "%.16G", value);
 #endif
-            {
-                size_t len = strlen(num);
-                memcpy(buf + n, num, len);
-                n += (int) len;
-            }
+        {
+            size_t len = strlen(num);
+            memcpy(buf + n, num, len);
+            n += (int) len;
         }
-
-        memcpy(buf + n, "</v></c>", 8);
-        n += 8;
-        _obuf_write(self, buf, (size_t) n);
-        return;
     }
 
-#ifdef USE_DTOA_LIBRARY
-    char data[LXLSX_ATTR_32];
+    memcpy(buf + n, "</v></c>", 8);
+    n += 8;
 
-    lxlsx_sprintf_dbl(data, cell->data.writer.value.number);
-
-    if (style_index)
-        fprintf(self->file,
-                "<c r=\"%s\" s=\"%d\"><v>%s</v></c>",
-                range, style_index, data);
+    if (self->optimize)
+        _obuf_write(self, buf, (size_t) n);
     else
-        fprintf(self->file, "<c r=\"%s\"><v>%s</v></c>", range, data);
-#else
-    if (style_index)
-        fprintf(self->file,
-                "<c r=\"%s\" s=\"%d\"><v>%.16G</v></c>",
-                range, style_index, cell->data.writer.value.number);
-    else
-        fprintf(self->file,
-                "<c r=\"%s\"><v>%.16G</v></c>", range,
-                cell->data.writer.value.number);
-
-#endif
+        (void) fwrite(buf, 1, (size_t) n, self->file);
 }
 
 /*
  * Write out a string worksheet cell. Doesn't use the xml functions as an
- * optimization in the inner cell writing loop.
+ * optimization in the inner cell writing loop; assembled and emitted the
+ * same way as _write_number_cell() in both modes.
  */
 STATIC void
-_write_string_cell(lxlsx_worksheet *self, char *range,
-                   int32_t style_index, lxlsx_cell *cell)
+_write_string_cell(lxlsx_worksheet *self, int32_t style_index,
+                   lxlsx_cell *cell)
 {
-    /* constant_memory fast path. */
-    if (self->optimize) {
-        char buf[80];
-        int n = _cell_ref_prefix(buf, cell->row_num, cell->col_num,
-                                 style_index);
-        memcpy(buf + n, " t=\"s\"><v>", 10);
-        n += 10;
-        n += _u32_dec(buf + n, (uint32_t) cell->data.writer.value.shared_string.id);
-        memcpy(buf + n, "</v></c>", 8);
-        n += 8;
-        _obuf_write(self, buf, (size_t) n);
-        return;
-    }
+    char buf[80];
+    int n = _cell_ref_prefix(buf, cell->row_num, cell->col_num, style_index);
 
-    if (style_index)
-        fprintf(self->file,
-                "<c r=\"%s\" s=\"%d\" t=\"s\"><v>%d</v></c>",
-                range, style_index,
-                cell->data.writer.value.shared_string.id);
+    memcpy(buf + n, " t=\"s\"><v>", 10);
+    n += 10;
+    n += _u32_dec(buf + n, (uint32_t) cell->data.writer.value.shared_string.id);
+    memcpy(buf + n, "</v></c>", 8);
+    n += 8;
+
+    if (self->optimize)
+        _obuf_write(self, buf, (size_t) n);
     else
-        fprintf(self->file,
-                "<c r=\"%s\" t=\"s\"><v>%d</v></c>",
-                range, cell->data.writer.value.shared_string.id);
+        (void) fwrite(buf, 1, (size_t) n, self->file);
 }
 
 /*
@@ -4704,19 +4742,23 @@ _write_string_cell(lxlsx_worksheet *self, char *range,
  * optimization in the inner cell writing loop.
  */
 STATIC void
-_write_inline_string_cell(lxlsx_worksheet *self, char *range,
-                          int32_t style_index, lxlsx_cell *cell)
+_write_inline_string_cell(lxlsx_worksheet *self, int32_t style_index,
+                          lxlsx_cell *cell)
 {
-    char *string = lxlsx_escape_data(cell->data.writer.value.string);
-    size_t slen = strlen(string);
+    const char *raw = cell->data.writer.value.string;
+    size_t rlen = raw ? strlen(raw) : 0;
 
-    /* constant_memory fast path. The escaped string may exceed the buffer, so
-     * it is appended through _obuf_write which streams oversized fragments. */
+    /* Whitespace is never escaped, so deciding xml:space on the raw string
+     * matches the escaped form byte for byte. */
+    int preserve = rlen
+        && (isspace((unsigned char) raw[0])
+            || isspace((unsigned char) raw[rlen - 1]));
+
+    /* constant_memory fast path: escape straight into the stream buffer,
+     * skipping the intermediate worst-case (5x) heap copy entirely. Oversized
+     * chunks stream through _obuf_write. */
     if (self->optimize) {
         char buf[96];
-        int preserve = slen
-            && (isspace((unsigned char) string[0])
-                || isspace((unsigned char) string[slen - 1]));
         int n = _cell_ref_prefix(buf, cell->row_num, cell->col_num,
                                  style_index);
         if (preserve) {
@@ -4728,39 +4770,43 @@ _write_inline_string_cell(lxlsx_worksheet *self, char *range,
             n += 22;
         }
         _obuf_write(self, buf, (size_t) n);
-        _obuf_write(self, string, slen);
+        (void) lxlsx_xml_escape_data_write(raw, _obuf_escape_cb, self);
         _obuf_write(self, "</t></is></c>", 13);
-        free(string);
         return;
     }
 
-    /* Add attribute to preserve leading or trailing whitespace. */
-    if (isspace((unsigned char) string[0])
-        || isspace((unsigned char) string[slen - 1])) {
+    {
+        char range[LXLSX_MAX_CELL_NAME_LENGTH];
+        char *string = lxlsx_escape_data(raw);
 
-        if (style_index)
-            fprintf(self->file,
-                    "<c r=\"%s\" s=\"%d\" t=\"inlineStr\"><is>"
-                    "<t xml:space=\"preserve\">%s</t></is></c>",
-                    range, style_index, string);
-        else
-            fprintf(self->file,
-                    "<c r=\"%s\" t=\"inlineStr\"><is>"
-                    "<t xml:space=\"preserve\">%s</t></is></c>",
-                    range, string);
-    }
-    else {
-        if (style_index)
-            fprintf(self->file,
-                    "<c r=\"%s\" s=\"%d\" t=\"inlineStr\">"
-                    "<is><t>%s</t></is></c>", range, style_index, string);
-        else
-            fprintf(self->file,
-                    "<c r=\"%s\" t=\"inlineStr\">"
-                    "<is><t>%s</t></is></c>", range, string);
-    }
+        lxlsx_rowcol_to_cell(range, cell->row_num, cell->col_num);
 
-    free(string);
+        /* Add attribute to preserve leading or trailing whitespace. */
+        if (preserve) {
+            if (style_index)
+                fprintf(self->file,
+                        "<c r=\"%s\" s=\"%d\" t=\"inlineStr\"><is>"
+                        "<t xml:space=\"preserve\">%s</t></is></c>",
+                        range, style_index, string);
+            else
+                fprintf(self->file,
+                        "<c r=\"%s\" t=\"inlineStr\"><is>"
+                        "<t xml:space=\"preserve\">%s</t></is></c>",
+                        range, string);
+        }
+        else {
+            if (style_index)
+                fprintf(self->file,
+                        "<c r=\"%s\" s=\"%d\" t=\"inlineStr\">"
+                        "<is><t>%s</t></is></c>", range, style_index, string);
+            else
+                fprintf(self->file,
+                        "<c r=\"%s\" t=\"inlineStr\">"
+                        "<is><t>%s</t></is></c>", range, string);
+        }
+
+        free(string);
+    }
 }
 
 /*
@@ -4912,16 +4958,10 @@ _write_cell(lxlsx_worksheet *self, lxlsx_cell *cell, lxlsx_format *row_format)
 {
     struct lxlsx_xml_attribute_list attributes;
     struct lxlsx_xml_attribute *attribute;
-    char range[LXLSX_MAX_CELL_NAME_LENGTH] = { 0 };
+    char range[LXLSX_MAX_CELL_NAME_LENGTH];
     lxlsx_row_t row_num = cell->row_num;
     lxlsx_col_t col_num = cell->col_num;
     int32_t style_index = 0;
-
-    /* In constant_memory mode the hot cell writers below build their own cell
-     * reference from row/col, so skip the snprintf-backed range conversion
-     * here; cold cell types recompute it after flushing the stream buffer. */
-    if (!self->optimize)
-        lxlsx_rowcol_to_cell(range, row_num, col_num);
 
     if (cell->data.writer.format) {
         style_index = lxlsx_format_get_xf_index(cell->data.writer.format);
@@ -4933,30 +4973,32 @@ _write_cell(lxlsx_worksheet *self, lxlsx_cell *cell, lxlsx_format *row_format)
         style_index = lxlsx_format_get_xf_index(self->col_formats[col_num]);
     }
 
-    /* Unrolled optimization for most commonly written cell types. */
+    /* Unrolled optimization for most commonly written cell types: these
+     * build their own cell reference from row/col with the hand-rolled
+     * formatters in both modes, so the snprintf-backed range conversion
+     * below is only needed for the cold cell types. */
     if (cell->type == NUMBER_CELL) {
-        _write_number_cell(self, range, style_index, cell);
+        _write_number_cell(self, style_index, cell);
         return;
     }
 
     if (cell->type == STRING_CELL) {
-        _write_string_cell(self, range, style_index, cell);
+        _write_string_cell(self, style_index, cell);
         return;
     }
 
     if (cell->type == INLINE_STRING_CELL) {
-        _write_inline_string_cell(self, range, style_index, cell);
+        _write_inline_string_cell(self, style_index, cell);
         return;
     }
 
     /* Remaining cell types are rare in bulk writes and still use the fprintf /
      * lxlsx_xml path writing directly to self->file. In constant_memory mode,
-     * flush the stream buffer (to preserve ordering) and materialise the cell
-     * reference that the hot path skipped. */
-    if (self->optimize) {
+     * flush the stream buffer first to preserve ordering. */
+    if (self->optimize)
         _obuf_flush(self);
-        lxlsx_rowcol_to_cell(range, row_num, col_num);
-    }
+
+    lxlsx_rowcol_to_cell(range, row_num, col_num);
 
     if (cell->type == INLINE_RICH_STRING_CELL) {
         _write_inline_rich_string_cell(self, range, style_index, cell);
@@ -5110,7 +5152,7 @@ lxlsx_worksheet_write_single_row(lxlsx_worksheet *self)
         for (col = self->dim_colmin; col <= self->dim_colmax; col++) {
             if (self->array[col]) {
                 _write_cell(self, self->array[col], row->format);
-                _free_cell(self->array[col]);
+                _recycle_cell(self, self->array[col]);
                 self->array[col] = NULL;
             }
         }
@@ -8327,7 +8369,7 @@ lxlsx_worksheet_write_number(lxlsx_worksheet *self,
     if (err)
         return err;
 
-    cell = _new_number_cell(row_num, col_num, value, format);
+    cell = _new_number_cell(self, row_num, col_num, value, format);
 
     _insert_cell(self, row_num, col_num, cell);
 
@@ -8392,7 +8434,7 @@ lxlsx_worksheet_write_string(lxlsx_worksheet *self,
             return LXLSX_ERROR_SHARED_STRING_INDEX_NOT_FOUND;
 
         string_id = lxlsx_sst_element->index;
-        cell = _new_string_cell(row_num, col_num, string_id,
+        cell = _new_string_cell(self, row_num, col_num, string_id,
                                 lxlsx_sst_element->string, format);
     }
     else {
@@ -8403,7 +8445,7 @@ lxlsx_worksheet_write_string(lxlsx_worksheet *self,
         else {
             string_copy = lxlsx_strdup(string);
         }
-        cell = _new_inline_string_cell(row_num, col_num, string_copy, format);
+        cell = _new_inline_string_cell(self, row_num, col_num, string_copy, format);
     }
 
     _insert_cell(self, row_num, col_num, cell);
@@ -8462,7 +8504,7 @@ lxlsx_worksheet_write_formula_num(lxlsx_worksheet *self,
     else
         formula_copy = lxlsx_strdup(formula);
 
-    cell = _new_formula_cell(row_num, col_num, formula_copy, format);
+    cell = _new_formula_cell(self, row_num, col_num, formula_copy, format);
     cell->data.writer.value.formula->result = result;
 
     _insert_cell(self, row_num, col_num, cell);
@@ -8519,7 +8561,7 @@ lxlsx_worksheet_write_formula_str(lxlsx_worksheet *self,
     else
         formula_copy = lxlsx_strdup(formula);
 
-    cell = _new_formula_cell(row_num, col_num, formula_copy, format);
+    cell = _new_formula_cell(self, row_num, col_num, formula_copy, format);
     cell->data.writer.value.formula->result_string = lxlsx_strdup(result);
 
     _insert_cell(self, row_num, col_num, cell);
@@ -8621,7 +8663,7 @@ _store_array_formula(lxlsx_worksheet *self,
     }
 
     /* Create a new array formula cell object. */
-    cell = _new_array_formula_cell(first_row, first_col,
+    cell = _new_array_formula_cell(self, first_row, first_col,
                                    formula_copy, range, format, is_dynamic);
 
     cell->data.writer.value.formula->result = result;
@@ -8761,7 +8803,7 @@ lxlsx_worksheet_write_blank(lxlsx_worksheet *self,
     if (err)
         return err;
 
-    cell = _new_blank_cell(row_num, col_num, format);
+    cell = _new_blank_cell(self, row_num, col_num, format);
 
     _insert_cell(self, row_num, col_num, cell);
 
@@ -8796,7 +8838,7 @@ lxlsx_worksheet_write_boolean(lxlsx_worksheet *self,
     if (err)
         return err;
 
-    cell = _new_boolean_cell(row_num, col_num, value, format);
+    cell = _new_boolean_cell(self, row_num, col_num, value, format);
 
     _insert_cell(self, row_num, col_num, cell);
 
@@ -8850,7 +8892,7 @@ lxlsx_worksheet_write_datetime(lxlsx_worksheet *self,
     excel_date =
         lxlsx_datetime_to_excel_date_with_epoch(datetime, self->use_1904_epoch);
 
-    cell = _new_number_cell(row_num, col_num, excel_date, format);
+    cell = _new_number_cell(self, row_num, col_num, excel_date, format);
 
     _insert_cell(self, row_num, col_num, cell);
 
@@ -8880,7 +8922,7 @@ lxlsx_worksheet_write_unixtime(lxlsx_worksheet *self,
     excel_date =
         lxlsx_unixtime_to_excel_date_with_epoch(unixtime, self->use_1904_epoch);
 
-    cell = _new_number_cell(row_num, col_num, excel_date, format);
+    cell = _new_number_cell(self, row_num, col_num, excel_date, format);
 
     _insert_cell(self, row_num, col_num, cell);
 
@@ -9069,7 +9111,7 @@ lxlsx_worksheet_write_url_opt(lxlsx_worksheet *self,
     /* Reset default error condition. */
     err = LXLSX_ERROR_MEMORY_MALLOC_FAILED;
 
-    link = _new_hyperlink_cell(row_num, col_num, link_type, url_copy,
+    link = _new_hyperlink_cell(self, row_num, col_num, link_type, url_copy,
                                url_string, tooltip_copy);
     GOTO_LABEL_ON_MEM_ERROR(link, mem_error);
 
@@ -9226,7 +9268,7 @@ lxlsx_worksheet_write_rich_string(lxlsx_worksheet *self,
             return LXLSX_ERROR_SHARED_STRING_INDEX_NOT_FOUND;
 
         string_id = lxlsx_sst_element->index;
-        cell = _new_string_cell(row_num, col_num, string_id,
+        cell = _new_string_cell(self, row_num, col_num, string_id,
                                 lxlsx_sst_element->string, format);
     }
     else {
@@ -9238,7 +9280,7 @@ lxlsx_worksheet_write_rich_string(lxlsx_worksheet *self,
         else {
             string_copy = rich_string;
         }
-        cell = _new_inline_rich_string_cell(row_num, col_num, string_copy,
+        cell = _new_inline_rich_string_cell(self, row_num, col_num, string_copy,
                                             format);
     }
 
@@ -9292,7 +9334,7 @@ lxlsx_worksheet_write_comment_opt(lxlsx_worksheet *self,
     comment->row = row_num;
     comment->col = col_num;
 
-    cell = _new_comment_cell(row_num, col_num, comment);
+    cell = _new_comment_cell(self, row_num, col_num, comment);
     GOTO_LABEL_ON_MEM_ERROR(cell, mem_error);
 
     _insert_comment(self, row_num, col_num, cell);
@@ -10748,7 +10790,9 @@ lxlsx_worksheet_repeat_columns(lxlsx_worksheet *self, lxlsx_col_t first_col,
         first_col = tmp_col;
     }
 
-    err = _check_dimensions(self, last_col, 0, LXLSX_IGNORE, LXLSX_IGNORE);
+    /* last_col is a column: validate it against the column limit, not the
+     * row limit (columns 16384..1048575 used to be accepted). */
+    err = _check_dimensions(self, 0, last_col, LXLSX_IGNORE, LXLSX_IGNORE);
     if (err)
         return err;
 
@@ -12405,7 +12449,7 @@ lxlsx_worksheet_set_error_cell(lxlsx_worksheet *self,
     lxlsx_col_t col_num = object_props->col;
 
     lxlsx_cell *cell =
-        _new_error_cell(row_num, col_num, ref_id, object_props->format);
+        _new_error_cell(self, row_num, col_num, ref_id, object_props->format);
     _insert_cell(self, row_num, col_num, cell);
 
 }
@@ -12565,7 +12609,6 @@ static void emit_cell(lxlsx_reader_worksheet *ws, lxlsx_cell *out)
 static void reset_cell(lxlsx_reader_worksheet *ws)
 {
     ws->cell_t[0] = 0;
-    ws->cell_ref[0] = 0;
     ws->cell_style_id = 0;
     ws->cell_value_len = 0;
     if (ws->cell_value) ws->cell_value[0] = 0;
@@ -12748,10 +12791,6 @@ static void on_start(void *ud, const char *name, const char **attrs)
             const char *s_attr = lxlsx_reader_xml_attr(attrs, "s");
 
             reset_cell(ws);
-            if (lxlsx_reader_copy_attr(ws->cell_ref, sizeof(ws->cell_ref), r_attr) != 0) {
-                fail_parse(ws, LXLSX_READER_ERROR_INVALID_CELL_REF);
-                return;
-            }
             if (lxlsx_reader_copy_attr(ws->cell_t, sizeof(ws->cell_t), t_attr) != 0) {
                 fail_parse(ws, LXLSX_READER_ERROR_FILE_CORRUPTED);
                 return;

--- a/library/libxlsx/src/xml_pump.c
+++ b/library/libxlsx/src/xml_pump.c
@@ -281,16 +281,25 @@ const char *lxlsx_reader_xml_attr(const char **attrs, const char *name)
 
 int lxlsx_reader_xml_name_eq(const char *xml_name, const char *want)
 {
+    const char *n, *w;
     size_t xn_len, w_len;
     const char *colon;
+
     if (!xml_name || !want) return 0;
+
+    /* Fast path: exact match, the overwhelmingly common case. One fused walk
+     * replaces the two unconditional strlen() passes this function used to
+     * make on every element/attribute probe (~10 probes per cell). */
+    n = xml_name;
+    w = want;
+    while (*n && *n == *w) { n++; w++; }
+    if (*n == '\0' && *w == '\0') return 1;
+
+    /* Allow prefix:want (namespaced documents only). */
     xn_len = strlen(xml_name);
     w_len  = strlen(want);
+    if (xn_len <= w_len) return 0;
 
-    if (xn_len == w_len) return strcmp(xml_name, want) == 0;
-    if (xn_len < w_len)  return 0;
-
-    /* Allow prefix:want */
     colon = xml_name + (xn_len - w_len) - 1;
     if (*colon != ':') return 0;
     return strcmp(colon + 1, want) == 0;

--- a/library/libxlsx/src/xmlwriter.c
+++ b/library/libxlsx/src/xmlwriter.c
@@ -165,6 +165,32 @@ lxlsx_xml_rich_si_element(FILE *xmlfile, const char *string)
 }
 
 /*
+ * Write a <t> element for a shared-string or rich-string fragment, adding
+ * xml:space="preserve" when leading/trailing whitespace must survive. Shared
+ * by shared_strings.c and styles.c so the whitespace heuristic lives in one
+ * place; the length guard keeps an empty string from reading string[-1].
+ */
+void
+lxlsx_xml_write_t_element(FILE *xmlfile, const char *string)
+{
+    struct lxlsx_xml_attribute_list attributes;
+    struct lxlsx_xml_attribute *attribute;
+    size_t len = string ? strlen(string) : 0;
+
+    LXLSX_INIT_ATTRIBUTES();
+
+    /* Add attribute to preserve leading or trailing whitespace. */
+    if (len
+        && (isspace((unsigned char) string[0])
+            || isspace((unsigned char) string[len - 1])))
+        LXLSX_PUSH_ATTRIBUTES_STR("xml:space", "preserve");
+
+    lxlsx_xml_data_element(xmlfile, "t", string, &attributes);
+
+    LXLSX_FREE_ATTRIBUTES();
+}
+
+/*
  * Escape XML characters in attributes.
  */
 STATIC char *
@@ -285,7 +311,10 @@ lxlsx_escape_data(const char *data)
 {
     size_t encoded_len = (strlen(data) * 5 + 1);
 
-    char *encoded = (char *) calloc(encoded_len, 1);
+    /* Plain malloc: the escape callback below fills exactly the bytes it
+     * needs and the terminator is written explicitly, so zeroing the whole
+     * worst-case buffer (5x the input) would be pure waste. */
+    char *encoded = (char *) malloc(encoded_len);
     char *p_encoded = encoded;
 
     if (!encoded)
@@ -297,6 +326,7 @@ lxlsx_escape_data(const char *data)
         return NULL;
     }
 
+    *p_encoded = '\0';
     return encoded;
 }
 

--- a/tests/validation_datetime_setters_return_this.phpt
+++ b/tests/validation_datetime_setters_return_this.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Validation datetime setters return $this for chaining
+--SKIPIF--
+<?php
+require __DIR__ . '/include/skipif.inc';
+?>
+--FILE--
+<?php
+$config = ['path' => './tests'];
+
+/* minimumDatetime/maximumDatetime in non-terminal chain position used to
+ * return null instead of $this, fataling on the next chained call. */
+$between = new \Vtiful\Kernel\Validation();
+$ret = $between->validationType(\Vtiful\Kernel\Validation::TYPE_DATE)
+    ->criteriaType(\Vtiful\Kernel\Validation::CRITERIA_BETWEEN)
+    ->minimumDatetime(mktime(0, 0, 0, 1, 1, 2024))
+    ->maximumDatetime(mktime(0, 0, 0, 12, 31, 2024))
+    ->ignoreBlank(true);
+var_dump($ret instanceof \Vtiful\Kernel\Validation);
+
+$greater = new \Vtiful\Kernel\Validation();
+$ret = $greater->validationType(\Vtiful\Kernel\Validation::TYPE_DATE)
+    ->criteriaType(\Vtiful\Kernel\Validation::CRITERIA_GREATER_THAN)
+    ->valueDatetime(mktime(0, 0, 0, 6, 1, 2024))
+    ->showInput(true);
+var_dump($ret instanceof \Vtiful\Kernel\Validation);
+
+/* Round-trip: chained datetime validations still produce a loadable file. */
+$excel    = new \Vtiful\Kernel\Excel($config);
+$filePath = $excel->fileName('validation_datetime_setters_return_this.xlsx')
+    ->validation('A1', $between->toResource())
+    ->validation('B1', $greater->toResource())
+    ->output();
+var_dump($filePath);
+
+$reader = new \Vtiful\Kernel\Excel($config);
+$data   = $reader->openFile('validation_datetime_setters_return_this.xlsx')
+                 ->openSheet()->getSheetData();
+var_dump($data);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . '/validation_datetime_setters_return_this.xlsx');
+?>
+--EXPECT--
+bool(true)
+bool(true)
+string(52) "./tests/validation_datetime_setters_return_this.xlsx"
+array(0) {
+}


### PR DESCRIPTION
Bug fixes, hot-path performance work and 32-bit/Windows portability fixes from a full-code review. All writer output is verified **byte-identical** (per-part XML diff of normal + constant-memory probe workbooks before/after every change).

## Bugs

- **validation**: `valueDatetime` / `minimumDatetime` / `maximumDatetime` now return `$this` like every other setter, restoring fluent chaining. Previously any chain such as `->minimumDatetime($a)->maximumDatetime($b)` fataled on a null return. Regression test added (`tests/validation_datetime_setters_return_this.phpt`).
- **workbook**: `add_worksheet` / `add_chartsheet` allocated the `lxlsx_sheet` wrapper *after* linking the new sheet into the workbook lists; if that allocation failed, the error path shallow-freed a node that was still reachable (dangling STAILQ entry + leaked worksheet internals). The wrapper is now allocated up front, so no failure path remains once anything is linked.
- **xmlwriter**: the `<t>` writer existed twice (`shared_strings.c` / `styles.c`), both reading `string[strlen(string) - 1]` — an out-of-bounds read for an empty string. Replaced by one shared, length-guarded `lxlsx_xml_write_t_element()`.
- **excel**: `constMemory()` now validates the configured `path` up front exactly like `fileName()` (exception 121), instead of failing much later at `output()`.
- **worksheet**: `repeat_columns()` validated `last_col` against the *row* limit, silently accepting out-of-range columns.

## Performance

Byte-identical output; benchmarks on arm64 macOS (median of interleaved runs for the reader):

| Benchmark | Before | After |
|---|---|---|
| write, normal mode, 150k×50 numeric | 4.29s | **3.49s (−19%)** |
| write, constMemory cell loop, 300k×50 num / 150k×50 str | 0.70s / 0.77s | **0.52s / 0.53s (−26% / −31%)** |
| read, 300k×20 via `nextRow()` | 3.77s | **3.55s (−5.6%)** |

- **reader**: `lxlsx_reader_xml_name_eq()` gains an exact-match fast path — the old implementation ran two unconditional `strlen()` per element/attribute probe (~10 probes per cell). Also removed a per-cell copy of the cell reference into a buffer that nothing ever read.
- **writer, normal mode**: number / shared-string / inline-string cells are now assembled with the same hand-rolled formatters as constant-memory mode and emitted with a single `fwrite`, replacing per-cell `fprintf` format parsing plus a `snprintf`-backed range string.
- **writer, constant-memory mode**: cell structs are recycled through a per-worksheet pool instead of a `calloc`/`free` round trip per cell, and inline strings escape directly into the stream buffer instead of via a worst-case 5×-sized, fully zeroed heap copy.
- **excel glue**: the loop-invariant `object_format()` lookup is hoisted out of `data()`'s per-cell loop.

## Portability (follows up on the new 32-bit CI)

- Whole-file sizes and ZIP offsets are queried via 64-bit `ftell` (`ftello` / `_ftelli64`) — plain `ftell` returns `long`, capping the writer capture and edit-mode open at 2GB on Windows and ILP32, and leaving the ZIP64 4GB offset guard dead there. The packager capture also gains the zero-length guards its `utility.c` twin already had.
- `lxlsx_sst_element` fields reordered: 64 → 56 bytes per unique shared string on LP64.

## Verification

- Per-part XML byte diff (normal + constMemory probes: ints, floats, negatives, 1e15, escapes, padded/UTF-8 strings, formulas, dates, URLs, merged cells) — identical at every step
- `make test`: 185/185, and 185/185 again with `USE_ZEND_ALLOC=0`
- `leaks --atExit` with Zend MM disabled on `bench/leak_stress.php`: 0 leaks
