### PR TITLE
fix: adapt timestamp_to_datetime() to PHP 8.6 php_idate() signature

### DIFF
--- a/kernel/common.c
+++ b/kernel/common.c
@@ -94,12 +94,23 @@ void call_object_method(zval *object, const char *function_name, uint32_t param_
 /* {{{ */
 lxlsx_datetime timestamp_to_datetime(zend_long timestamp)
 {
+#if PHP_VERSION_ID >= 80600
+    int yearLocal, monthLocal, dayLocal, hourLocal, minuteLocal, secondLocal;
+
+    php_idate('Y', timestamp, 0, &yearLocal);
+    php_idate('m', timestamp, 0, &monthLocal);
+    php_idate('d', timestamp, 0, &dayLocal);
+    php_idate('H', timestamp, 0, &hourLocal);
+    php_idate('i', timestamp, 0, &minuteLocal);
+    php_idate('s', timestamp, 0, &secondLocal);
+#else
     int yearLocal   = php_idate('Y', timestamp, 0);
     int monthLocal  = php_idate('m', timestamp, 0);
     int dayLocal    = php_idate('d', timestamp, 0);
     int hourLocal   = php_idate('H', timestamp, 0);
     int minuteLocal = php_idate('i', timestamp, 0);
     int secondLocal = php_idate('s', timestamp, 0);
+#endif
 
     lxlsx_datetime datetime = {
             yearLocal, monthLocal, dayLocal, hourLocal, minuteLocal, secondLocal


### PR DESCRIPTION
PHP 8.6 (since 8.6.0alpha2) changed `php_idate()` to return `bool` and report the value via a new `int*` out-parameter:

```c
PHPAPI bool php_idate(char format, time_t ts, bool localtime, int *result);
```

so building against 8.6.0alpha2 fails with:

```
kernel/common.c:97:23: error: too few arguments to function 'php_idate'; expected 4, have 3
```

This adapts the six call sites in `timestamp_to_datetime()`, guarded with `PHP_VERSION_ID >= 80600` so all currently supported PHP versions keep the original calls. This should also fix the PHP 8.6 job added to CI in #589.

Verified locally on Alpine Linux edge: builds clean against both php86 (8.6.0_alpha2) and php85 (8.5.x); the extension test suite passes on 8.6 (0 failures, validated via the Alpine `php86-pecl-xlswriter` package build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)