### PR TITLE
tests: give each test its own scratch files

### DIFF
--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -6,8 +6,12 @@ Check for vtiful presence
 <?php
 $config = ['path' => './tests'];
 $excel = new \Vtiful\Kernel\Excel($config);
-$fileFd = $excel->fileName('tutorial01.xlsx');
+$fileFd = $excel->fileName('003.xlsx');
 var_dump($fileFd);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/003.xlsx");
 ?>
 --EXPECTF--
 object(Vtiful\Kernel\Excel)#%d (3) {
@@ -17,7 +21,7 @@ object(Vtiful\Kernel\Excel)#%d (3) {
     string(7) "./tests"
   }
   ["fileName":"Vtiful\Kernel\Excel":private]=>
-  string(23) "./tests/tutorial01.xlsx"
+  string(16) "./tests/003.xlsx"
   ["read_row_type":"Vtiful\Kernel\Excel":private]=>
   NULL
 }

--- a/tests/004.phpt
+++ b/tests/004.phpt
@@ -6,9 +6,13 @@ Check for vtiful presence
 <?php
 $config = ['path' => './tests'];
 $excel = new \Vtiful\Kernel\Excel($config);
-$fileFd = $excel->fileName('tutorial01.xlsx');
+$fileFd = $excel->fileName('004.xlsx');
 $setHeader = $fileFd->header(['Item', 'Cost']);
 var_dump($setHeader);
+?>
+--CLEAN--
+<?php
+@unlink(__DIR__ . "/004.xlsx");
 ?>
 --EXPECTF--
 object(Vtiful\Kernel\Excel)#%d (3) {
@@ -18,7 +22,7 @@ object(Vtiful\Kernel\Excel)#%d (3) {
     string(7) "./tests"
   }
   ["fileName":"Vtiful\Kernel\Excel":private]=>
-  string(23) "./tests/tutorial01.xlsx"
+  string(16) "./tests/004.xlsx"
   ["read_row_type":"Vtiful\Kernel\Excel":private]=>
   NULL
 }

--- a/tests/006.phpt
+++ b/tests/006.phpt
@@ -6,13 +6,13 @@ Check for vtiful presence
 <?php
 $config = ['path' => './tests'];
 $excel = new \Vtiful\Kernel\Excel($config);
-$handle = $excel->fileName('tutorial01.xlsx')
+$handle = $excel->fileName('006.xlsx')
     ->getHandle();
 var_dump($handle);
 ?>
 --CLEAN--
 <?php
-@unlink(__DIR__ . "/tutorial01.xlsx");
+@unlink(__DIR__ . "/006.xlsx");
 ?>
 --EXPECTF--
 resource(%d) of type (xlsx)

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -7,7 +7,7 @@ Check for vtiful presence
 $config = ['path' => './tests'];
 
 $excel  = new \Vtiful\Kernel\Excel($config);
-$handle = $excel->fileName('tutorial01.xlsx')->getHandle();
+$handle = $excel->fileName('007.xlsx')->getHandle();
 
 $format     = new \Vtiful\Kernel\Format($handle);
 $boldFormat = $format->bold()->toResource();
@@ -16,7 +16,7 @@ var_dump($boldFormat);
 ?>
 --CLEAN--
 <?php
-@unlink(__DIR__ . "/tutorial01.xlsx");
+@unlink(__DIR__ . "/007.xlsx");
 ?>
 --EXPECTF--
 resource(%d) of type (xlsx)

--- a/tests/008.phpt
+++ b/tests/008.phpt
@@ -7,7 +7,7 @@ Check for vtiful presence
 $config = ['path' => './tests'];
 
 $excel  = new \Vtiful\Kernel\Excel($config);
-$handle = $excel->fileName('tutorial01.xlsx')->getHandle();
+$handle = $excel->fileName('008.xlsx')->getHandle();
 
 $format      = new \Vtiful\Kernel\Format($handle);
 $italicStyle = $format->italic()->toResource();
@@ -16,7 +16,7 @@ var_dump($italicStyle);
 ?>
 --CLEAN--
 <?php
-@unlink(__DIR__ . "/tutorial01.xlsx");
+@unlink(__DIR__ . "/008.xlsx");
 ?>
 --EXPECTF--
 resource(%d) of type (xlsx)

--- a/tests/009.phpt
+++ b/tests/009.phpt
@@ -7,7 +7,7 @@ Check for vtiful presence
 $config = ['path' => './tests'];
 
 $excel  = new \Vtiful\Kernel\Excel($config);
-$handle = $excel->fileName('tutorial01.xlsx')->getHandle();
+$handle = $excel->fileName('009.xlsx')->getHandle();
 
 $format         = new \Vtiful\Kernel\Format($handle);
 $underlineStyle = $format->underline(\Vtiful\Kernel\Format::UNDERLINE_SINGLE)->toResource();
@@ -16,7 +16,7 @@ var_dump($underlineStyle);
 ?>
 --CLEAN--
 <?php
-@unlink(__DIR__ . "/tutorial01.xlsx");
+@unlink(__DIR__ . "/009.xlsx");
 ?>
 --EXPECTF--
 resource(%d) of type (xlsx)

--- a/tests/xlsx_to_csv.phpt
+++ b/tests/xlsx_to_csv.phpt
@@ -15,7 +15,7 @@ $filePath = $excel->fileName('xlsx_to_csv.xlsx', 'TestSheet1')
     ])
     ->output();
 
-$fp = fopen('./tests/file.csv', 'w');
+$fp = fopen('./tests/xlsx_to_csv.csv', 'w');
 
 $csvResult = $excel->openFile('xlsx_to_csv.xlsx')
     ->openSheet()
@@ -26,7 +26,7 @@ var_dump($csvResult);
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/xlsx_to_csv.xlsx');
-@unlink(__DIR__ . '/file.csv');
+@unlink(__DIR__ . '/xlsx_to_csv.csv');
 ?>
 --EXPECT--
 bool(true)

--- a/tests/xlsx_to_csv_callback.phpt
+++ b/tests/xlsx_to_csv_callback.phpt
@@ -15,7 +15,7 @@ $filePath = $excel->fileName('xlsx_to_csv_callback.xlsx', 'TestSheet1')
     ])
     ->output();
 
-$fp = fopen('./tests/file.csv', 'w');
+$fp = fopen('./tests/xlsx_to_csv_callback.csv', 'w');
 
 $csvResult = $excel->openFile('xlsx_to_csv_callback.xlsx')
     ->openSheet()
@@ -27,7 +27,7 @@ fclose($fp);
 
 var_dump($csvResult);
 
-$fp = fopen('./tests/file.csv', 'r');
+$fp = fopen('./tests/xlsx_to_csv_callback.csv', 'r');
 
 var_dump(fgetcsv($fp, 1000, ',', '"', '\\'));
 var_dump(fgetcsv($fp, 1000, ',', '"', '\\'));
@@ -35,7 +35,7 @@ var_dump(fgetcsv($fp, 1000, ',', '"', '\\'));
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/xlsx_to_csv_callback.xlsx');
-@unlink(__DIR__ . '/file.csv');
+@unlink(__DIR__ . '/xlsx_to_csv_callback.csv');
 ?>
 --EXPECT--
 bool(true)

--- a/tests/xlsx_to_csv_callback_custom_delimiter.phpt
+++ b/tests/xlsx_to_csv_callback_custom_delimiter.phpt
@@ -15,7 +15,7 @@ $filePath = $excel->fileName('xlsx_to_csv_callback_custom_delimiter.xlsx', 'Test
     ])
     ->output();
 
-$fp = fopen('./tests/file.csv', 'w');
+$fp = fopen('./tests/xlsx_to_csv_callback_custom_delimiter.csv', 'w');
 
 $csvResult = $excel->openFile('xlsx_to_csv_callback_custom_delimiter.xlsx')
     ->openSheet()
@@ -25,7 +25,7 @@ $csvResult = $excel->openFile('xlsx_to_csv_callback_custom_delimiter.xlsx')
 
 var_dump($csvResult);
 
-if (($csvHandler = fopen('./tests/file.csv', 'r')) === FALSE) {
+if (($csvHandler = fopen('./tests/xlsx_to_csv_callback_custom_delimiter.csv', 'r')) === FALSE) {
     die('csv file open failure');
 }
 
@@ -36,7 +36,7 @@ while (($data = fgetcsv($csvHandler, 1000, ';', '"', '\\')) !== FALSE) {
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/xlsx_to_csv_callback_custom_delimiter.xlsx');
-@unlink(__DIR__ . '/file.csv');
+@unlink(__DIR__ . '/xlsx_to_csv_callback_custom_delimiter.csv');
 ?>
 --EXPECT--
 bool(true)

--- a/tests/xlsx_to_csv_custom_delimiter.phpt
+++ b/tests/xlsx_to_csv_custom_delimiter.phpt
@@ -15,7 +15,7 @@ $filePath = $excel->fileName('xlsx_to_csv_custom_delimiter.xlsx', 'TestSheet1')
     ])
     ->output();
 
-$fp = fopen('./tests/file.csv', 'w');
+$fp = fopen('./tests/xlsx_to_csv_custom_delimiter.csv', 'w');
 
 $csvResult = $excel->openFile('xlsx_to_csv_custom_delimiter.xlsx')
     ->openSheet()
@@ -23,7 +23,7 @@ $csvResult = $excel->openFile('xlsx_to_csv_custom_delimiter.xlsx')
 
 var_dump($csvResult);
 
-if (($csvHandler = fopen('./tests/file.csv', 'r')) === FALSE) {
+if (($csvHandler = fopen('./tests/xlsx_to_csv_custom_delimiter.csv', 'r')) === FALSE) {
     die('csv file open failure');
 }
 
@@ -34,7 +34,7 @@ while (($data = fgetcsv($csvHandler, 1000, ';', '"', '\\')) !== FALSE) {
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/xlsx_to_csv_custom_delimiter.xlsx');
-@unlink(__DIR__ . '/file.csv');
+@unlink(__DIR__ . '/xlsx_to_csv_custom_delimiter.csv');
 ?>
 --EXPECT--
 bool(true)

--- a/tests/xlsx_to_csv_skip_rows.phpt
+++ b/tests/xlsx_to_csv_skip_rows.phpt
@@ -17,7 +17,7 @@ $filePath = $excel->fileName('xlsx_to_csv_skip_rows.xlsx', 'TestSheet1')
     ])
     ->output();
 
-$fp = fopen('./tests/file.csv', 'w');
+$fp = fopen('./tests/xlsx_to_csv_skip_rows.csv', 'w');
 
 $csvResult = $excel->openFile('xlsx_to_csv_skip_rows.xlsx')
     ->openSheet()
@@ -27,9 +27,9 @@ $csvResult = $excel->openFile('xlsx_to_csv_skip_rows.xlsx')
 fclose($fp);
 
 var_dump($csvResult);
-var_dump(file_get_contents('./tests/file.csv'));
+var_dump(file_get_contents('./tests/xlsx_to_csv_skip_rows.csv'));
 
-$fp = fopen('./tests/file.csv', 'w');
+$fp = fopen('./tests/xlsx_to_csv_skip_rows.csv', 'w');
 
 $csvResult = $excel->openFile('xlsx_to_csv_skip_rows.xlsx')
     ->openSheet()
@@ -39,12 +39,12 @@ $csvResult = $excel->openFile('xlsx_to_csv_skip_rows.xlsx')
 fclose($fp);
 
 var_dump($csvResult);
-var_dump(file_get_contents('./tests/file.csv'));
+var_dump(file_get_contents('./tests/xlsx_to_csv_skip_rows.csv'));
 ?>
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/xlsx_to_csv_skip_rows.xlsx');
-@unlink(__DIR__ . '/file.csv');
+@unlink(__DIR__ . '/xlsx_to_csv_skip_rows.csv');
 ?>
 --EXPECT--
 bool(true)

--- a/tests/xlsx_to_csv_skip_rows_callback.phpt
+++ b/tests/xlsx_to_csv_skip_rows_callback.phpt
@@ -17,7 +17,7 @@ $filePath = $excel->fileName('xlsx_to_csv_skip_rows_callback.xlsx', 'TestSheet1'
     ])
     ->output();
 
-$fp = fopen('./tests/file.csv', 'w');
+$fp = fopen('./tests/xlsx_to_csv_skip_rows_callback.csv', 'w');
 
 $csvResult = $excel->openFile('xlsx_to_csv_skip_rows_callback.xlsx')
     ->openSheet()
@@ -29,12 +29,12 @@ $csvResult = $excel->openFile('xlsx_to_csv_skip_rows_callback.xlsx')
 fclose($fp);
 
 var_dump($csvResult);
-var_dump(file_get_contents('./tests/file.csv'));
+var_dump(file_get_contents('./tests/xlsx_to_csv_skip_rows_callback.csv'));
 ?>
 --CLEAN--
 <?php
 @unlink(__DIR__ . '/xlsx_to_csv_skip_rows_callback.xlsx');
-@unlink(__DIR__ . '/file.csv');
+@unlink(__DIR__ . '/xlsx_to_csv_skip_rows_callback.csv');
 ?>
 --EXPECT--
 bool(true)


### PR DESCRIPTION
Six tests write and unlink the same `tests/file.csv`, and six more all generate `tests/tutorial01.xlsx` (003, 004, 006, 007, 008, 009). Since https://github.com/php/php-src/commit/1d2ea5ce22c ("Run tests in parallel by default", [GH-22939](https://github.com/php/php-src/pull/22939), first released in **php-8.6.0beta1**) run-tests.php spawns min(nproc, 10) workers by default, so these tests clobber each other's files and fail intermittently - `file_get_contents()` hits a path a sibling test has just removed.

003 and 004 had no `--CLEAN--` section at all, so they were also leaving `tutorial01.xlsx` behind after every run; they now remove their own file.